### PR TITLE
Faster directory checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,7 @@ performance-server:
 
 performance-stats:
 	python -c 'import pstats ; pstats.Stats("$(STATS_FILE)").sort_stats("$(STATS_METRIC)").print_stats()' | less
+
+clean:
+	rm -rf build/ dist/
+	find . -name '*.pyc' -delete

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -8,7 +8,7 @@ from dredis.utils import to_float
 
 DEFAULT_REDIS_DB = '0'
 NUMBER_OF_REDIS_DATABASES = 15
-DECIMAL_REGEX = re.compile('(\d+)\.0+$')
+DECIMAL_REGEX = re.compile(r'(\d+)\.0+$')
 
 
 class DiskKeyspace(object):

--- a/dredis/path.py
+++ b/dredis/path.py
@@ -6,6 +6,8 @@ import shutil
 import six
 import sys
 
+from scandir import scandir
+
 
 class Path(str):
 
@@ -71,7 +73,15 @@ class Path(str):
                     f.write(new_content)
 
     def empty_directory(self):
-        return self.exists() and not self.listdir()
+        if self.exists():
+            try:
+                next(scandir(self))
+            except StopIteration:
+                return True
+            else:
+                return False
+        else:
+            return False
 
     def _deserialize(self, value):
         return json.loads(value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 lupa
 six
+scandir

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def parse_requirements():
             continue
         if 'http:' in req or 'https:' in req:
             links.append(req)
-            name, version = re.findall("\#egg=([^\-]+)-(.+$)", req)[0]
+            name, version = re.findall(r"\#egg=([^\-]+)-(.+$)", req)[0]
             pkgs.append('{0}=={1}'.format(name, version))
         else:
             pkgs.append(req)

--- a/tests-performance/test_zset_performance.py
+++ b/tests-performance/test_zset_performance.py
@@ -2,16 +2,16 @@
 The following results should serve as reference
 ------
 
-Results from 2018-10-15 on @htlbra's Macbook (LARGE_NUMBER == 1000):
+Results from 2018-11-12 on @htlbra's Macbook (LARGE_NUMBER == 1000):
 
 $ make performance-server & make test-performance | grep 'zset Z'
-zset ZADD time = 0.45439s
-zset ZADD time = 0.67709s
-zset ZCARD time = 0.00124s
-zset ZRANK time = 0.00407s
-zset ZCOUNT time = 0.00450s
-zset ZRANGE time = 0.01875s
-zset ZREM time = 3.92562s
+zset ZADD time = 0.45149s
+zset ZADD time = 0.67749s
+zset ZCARD time = 0.00117s
+zset ZRANK time = 0.00437s
+zset ZCOUNT time = 0.00439s
+zset ZRANGE time = 0.02463s
+zset ZREM time = 3.69544s
 
 
 $ redis-server --port 6376 & make test-performance | grep time


### PR DESCRIPTION
I saw slows `ZREM` and `HDEL` when running large sorted sets, and that was because of the calls to `empty_directory()` (which calls `os.listdir()`).

In order to not retrieve information about all files in a given directory just to check if the directory is empty, I added the `scandir` package as a dependency. Both `scandir.scandir` and `os.listdir()` use the C function `readdir()`, however, with this pull request,`scandir.scandir` will only call `readdir()` once.

This showed a ~5% performance improvement for ZREM.