### PR TITLE
New binary file format

### DIFF
--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -122,9 +122,16 @@ class DiskKeyspace(object):
 
     def zadd(self, key, score, value):
         """
-        /path/scores/10 -> '"x1"\n"x2"'
-        /path/scores/20 -> '"y"'
-        /path/scores/30 -> '"z"'
+        score structure (binary)
+        ------
+        /path/to/scores/10 -> 8 bytes + (4 bytes + content)*
+        example:
+        0x0002   0x05 hello     0x05 world
+         count   size data      size data
+          2       5   "hello"   5    "world"
+
+        value structure
+        ------
         /path/values/hash("x1") -> "10"
         """
 
@@ -212,10 +219,7 @@ class DiskKeyspace(object):
 
     def zrem(self, key, *members):
         """
-        /path/scores/10 -> "x1\nx2"
-        /path/scores/20 -> "y"
-        /path/scores/30 -> "z"
-        /path/values/hash(x) -> 1
+        see zadd() for information about score and value structures
         """
         key_path = self._key_path(key)
         scores_path = key_path.join('scores')

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -265,7 +265,16 @@ class DiskKeyspace(object):
         return result
 
     def zcount(self, key, min_score, max_score):
-        return len(self.zrangebyscore(key, min_score, max_score))
+        key_path = self._key_path(key)
+        scores_path = key_path.join('scores')
+        count = 0
+        if scores_path.exists():
+            scores = sorted(scores_path.listdir(), key=float)
+            score_range = ScoreRange(min_score, max_score)
+            scores = [score for score in scores if score_range.check(float(score))]
+            for score in scores:
+                count += scores_path.join(score).read_zset_header()
+        return count
 
     def zrank(self, key, member):
         key_path = self._key_path(key)

--- a/dredis/path.py
+++ b/dredis/path.py
@@ -1,6 +1,5 @@
 import errno
 import fnmatch
-import json
 import os.path
 import shutil
 import struct
@@ -23,11 +22,11 @@ class Path(str):
     def read(self):
         with open(self, 'r') as f:
             result = f.read()
-        return self._deserialize(result)
+        return result
 
     def write(self, content):
         with open(self, 'w') as f:
-            f.write(self._serialize(content))
+            f.write(content)
 
     def delete(self):
         if os.path.isfile(self):
@@ -90,12 +89,6 @@ class Path(str):
                 return False
         else:
             return False
-
-    def _deserialize(self, value):
-        return json.loads(value)
-
-    def _serialize(self, value):
-        return json.dumps(value)
 
     def read_zset_header(self):
         with open(self, 'rb') as f:

--- a/dredis/path.py
+++ b/dredis/path.py
@@ -45,7 +45,7 @@ class Path(str):
             old_size = ZSetEncoder.read_header(f)
 
         ZSetEncoder.write_header(f, old_size + 1)
-        ZSetEncoder.write_element(f, line)
+        ZSetEncoder.write_element_to_eof(f, line)
 
     def readlines(self):
         with open(self, 'rb') as f:
@@ -120,9 +120,13 @@ class ZSetEncoder(object):
 
     @classmethod
     def write_element(cls, f, element):
-        f.seek(0, os.SEEK_END)
         f.write(struct.pack(cls.ELEMENT_FMT, len(element)))
         f.write(element)
+
+    @classmethod
+    def write_element_to_eof(cls, f, element):
+        cls.move_to_eof(f)
+        cls.write_element(f, element)
 
     @classmethod
     def read_element(cls, f):
@@ -148,3 +152,7 @@ class ZSetEncoder(object):
             elements.append(element)
             element = cls.read_element(f)
         return elements
+
+    @classmethod
+    def move_to_eof(cls, f):
+        f.seek(0, os.SEEK_END)

--- a/dredis/path.py
+++ b/dredis/path.py
@@ -113,3 +113,7 @@ class Path(str):
 
     def _serialize(self, value):
         return json.dumps(value)
+
+    def read_zset_header(self):
+        with open(self, 'rb') as f:
+            return struct.unpack(">Q", f.read(8))[0]

--- a/dredis/path.py
+++ b/dredis/path.py
@@ -140,12 +140,16 @@ class ZSetEncoder(object):
     @classmethod
     def read_elements(cls, f):
         elements = []
-        f.seek(cls.HEADER_BYTES)  # skip header
+        cls.skip_header(f)
         element = cls.read_element(f)
         while element:
             elements.append(element)
             element = cls.read_element(f)
         return elements
+
+    @classmethod
+    def skip_header(cls, f):
+        f.seek(cls.HEADER_BYTES, os.SEEK_SET)
 
     @classmethod
     def move_to_eof(cls, f):

--- a/dredis/path.py
+++ b/dredis/path.py
@@ -125,11 +125,8 @@ class ZSetEncoder(object):
     @classmethod
     def read_element(cls, f):
         size_string = f.read(cls.SIZE_BYTES)
-        if size_string:
-            size = struct.unpack(cls.ELEMENT_FMT, size_string)[0]
-            return f.read(size)
-        else:
-            return None
+        size = struct.unpack(cls.ELEMENT_FMT, size_string)[0]
+        return f.read(size)
 
     @classmethod
     def rewrite_content(cls, f, lines):
@@ -140,11 +137,10 @@ class ZSetEncoder(object):
     @classmethod
     def read_elements(cls, f):
         elements = []
-        cls.skip_header(f)
-        element = cls.read_element(f)
-        while element:
-            elements.append(element)
+        count = cls.read_header(f)
+        for _ in xrange(count):
             element = cls.read_element(f)
+            elements.append(element)
         return elements
 
     @classmethod

--- a/dredis/path.py
+++ b/dredis/path.py
@@ -20,12 +20,12 @@ class Path(str):
         os.makedirs(self)
 
     def read(self):
-        with open(self, 'r') as f:
+        with open(self, 'rb') as f:
             result = f.read()
         return result
 
     def write(self, content):
-        with open(self, 'w') as f:
+        with open(self, 'wb') as f:
             f.write(content)
 
     def delete(self):

--- a/dredis/path.py
+++ b/dredis/path.py
@@ -103,8 +103,9 @@ class ZSetEncoder(object):
     SIZE_BYTES = 4
 
     @classmethod
-    def write_header(cls, f, size):
-        f.seek(0, os.SEEK_SET)
+    def write_header(cls, f, size, seek_to_start=True):
+        if seek_to_start:
+            f.seek(0, os.SEEK_SET)
         f.write(struct.pack(cls.HEADER_FMT, size))
 
     @classmethod
@@ -132,7 +133,7 @@ class ZSetEncoder(object):
 
     @classmethod
     def rewrite_content(cls, f, lines):
-        cls.write_header(f, len(lines))
+        cls.write_header(f, len(lines), seek_to_start=False)
         for line in lines:
             cls.write_element(f, line)
 

--- a/tests-performance/test_zset_performance.py
+++ b/tests-performance/test_zset_performance.py
@@ -55,7 +55,7 @@ def test_zadd_rescore_same_element():
 def test_zcard():
     r = fresh_redis(port=PROFILE_PORT)
     for score in range(LARGE_NUMBER):
-        assert r.zadd('myzset', 0, 'value{}'.format(score)) == 1
+        assert r.zadd('myzset', score, 'value{}'.format(score)) == 1
     before_zcard = time.time()
     assert r.zcard('myzset') == LARGE_NUMBER
     after_zcard = time.time()

--- a/tests-performance/test_zset_performance.py
+++ b/tests-performance/test_zset_performance.py
@@ -5,13 +5,13 @@ The following results should serve as reference
 Results from 2018-11-12 on @htlbra's Macbook (LARGE_NUMBER == 1000):
 
 $ make performance-server & make test-performance | grep 'zset Z'
-zset ZADD time = 0.45149s
-zset ZADD time = 0.67749s
-zset ZCARD time = 0.00117s
-zset ZRANK time = 0.00437s
-zset ZCOUNT time = 0.00439s
-zset ZRANGE time = 0.02463s
-zset ZREM time = 3.69544s
+zset ZADD time = 0.46967s
+zset ZADD time = 0.69122s
+zset ZCARD time = 0.00120s
+zset ZRANK time = 0.00196s
+zset ZCOUNT time = 0.00030s
+zset ZRANGE time = 0.02062s
+zset ZREM time = 2.52095s
 
 
 $ redis-server --port 6376 & make test-performance | grep time

--- a/tests/integration/test_strings.py
+++ b/tests/integration/test_strings.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 import pytest
 import redis
 
@@ -24,6 +26,13 @@ def test_set_and_get_bytes():
 
     assert r.set('foo', b'\x05\x02\x03') is True
     assert r.get('foo') == b'\x05\x02\x03'
+
+
+def test_set_and_get_unicode_chars():
+    r = fresh_redis()
+
+    assert r.set(u'foo㐀㐁', u'㐂㐃') is True
+    assert r.get(u'foo㐀㐁') == u'㐂㐃'.encode('utf-8')  # there's unicode conversion in Redis
 
 
 def test_set_and_get_integer():


### PR DESCRIPTION
## Backward incompatibility

This branch has backward incompatible changes to the file formats of every data structure. There's no longer JSON serialization.

----

## New sorted set binary format

The sorted set file structure is the one with the most changes focusing on optimization. The new structure uses a binary format to store how many entries there are in each score file and also the size of each element before the element data.

I picked 8 bytes for the header because that gives us 2**64 capacity on each sorted set. I also picked 4 bytes for the data size because that gives each element 4GB of space.

The optimization results are approximately the following:
* ZRANK: 55% faster
* ZCOUNT: 93% faster
* ZRANGE: 16% faster
* ZREM: 31% faster

I've seen a ~5% time variation in performance test times on my laptop, please take that into account (the results are still very significant).
