### PR TITLE
Change storage to use LevelDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ HGETALL key                                  | Hashes
 ## How is DRedis implemented
 
 Initially DRedis had its own filesystem structure, but then it was converted to use [LevelDB](https://github.com/google/leveldb), which is a lot more reliable and faster.
-Other projects implement similar features to what's available with DRedis, but they aren't what Yipit needed when the project started.
+Other projects implement similar features to what's available on DRedis, but they aren't what Yipit needed when the project started.
 Some similar projects follow:
 
 * https://github.com/Qihoo360/pika

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ that can afford slower performance and want unlimited storage, DRedis may be an 
 
 ## Installing
 
+Make sure to install the [LevelDB](https://github.com/google/leveldb) C++ library (`apt-get install libleveldb-dev` or `brew install leveldb`) and then run:
+
 ```shell
 $ pip install dredis
 ```
@@ -86,42 +88,17 @@ HGETALL key                                  | Hashes
 
 ## How is DRedis implemented
 
-DRedis is created on top of the filesystem and relies on hierarchy (directories and files).
-There's a *root directory* to store all keys. Every database is a directory inside of the root directory.
-Every key is a directory inside of the database directory. Every key has a `type` file containing its type name (e.g., string, set, hash, zset).
+Initially DRedis had its own filesystem structure, but then it was converted to use [LevelDB](https://github.com/google/leveldb), which is a lot more reliable and faster.
+Other projects implement similar features to what's available with DRedis, but they aren't what Yipit needed when the project started.
+Some similar projects follow:
 
-Each supported key type has its own directory structure:
-* `String` keys have a `value` file and its content is the value of the key
-* `Set` keys have a `values` directory and each member of the set has a corresponding file (the content is the member value)
-* `Hash` keys have a `fields` directory and each field has a corresponding file (the content is the field value)
-* `Sorted set` key have a `scores` directory and a `values` directory.
-Each file in `scores` represents a score and its content contains all values of that score.
-Each file in `values` represents a value and its content is its score (constant time to access the score).
+* https://github.com/Qihoo360/pika
+* https://github.com/KernelMaker/blackwidow
+* https://github.com/siddontang/ledisdb
+* https://github.com/reborndb/qdb
+* https://github.com/alash3al/redix
+* https://github.com/meitu/titan
 
-After running `SET msg "Hello World"` the root directory will look like this:
-
-```
-$ tree /path/to/root-dir
-├── 0
-│   └── msg
-│       ├── type
-│       └── value
-├── 1
-├── 10
-├── 11
-├── 12
-├── 13
-├── 14
-├── 2
-├── 3
-├── 4
-├── 5
-├── 6
-├── 7
-├── 8
-└── 9
-
-```
 
 ## Lua support
 
@@ -132,19 +109,20 @@ Lua is supported through the [lupa](https://github.com/scoder/lupa) library.
 
 ### Data Consistency
 
-Some commands may have to write to multiple files and if the disk fails in-between those writes, there may be consistency issues.
-This project relies on the filesystem implementation (retry logic, etc). No hard-drive stress tests were performed. 
+We are relying on LevelDB's consistency, no stress tests were performed.
 
 ### Cluster mode & Replication
 
 Replication, key distribution, and cluster mode isn't supported.
-If you want higher availability you can create multiple servers that share or replicates a disk (consistency may suffer when replicating).
+If you want higher availability you can create multiple servers that share or replicate a disk (consistency may suffer when replicating).
 Use DNS routing or a network load balancer to route requests properly.
 
 ### Backups
 
 There are many solutions to back up files. DRedis will have no impact when backups are performed because it's done from the outside (different from Redis, which uses `fork()` to snapshot the data).
 A straightforward approach is to have period backups to an object storage such as Amazon S3.
+
+The commands SAVE or BGSAVE will be supported in the future to guarantee consistency when generating backups.
 
 This project includes a snapshot utility (`dredis-snapshot`) to make it easier to back up data locally or to AWS S3.
 Be aware that there may be consistency issues during the snapshot (`dredis` won't pause during the temporary copy of the data directory).

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -1,7 +1,7 @@
 import collections
 import fnmatch
 
-from dredis.ldb import LDB_DBS, LDB_KEY_TYPES, KEY_CODEC, get_ldb
+from dredis.ldb import LDB_DBS, LDB_KEY_TYPES, KEY_CODEC, open_ldb
 from dredis.lua import LuaRunner
 from dredis.path import Path
 from dredis.utils import to_float
@@ -32,7 +32,7 @@ class DiskKeyspace(object):
             db_id = str(db_id_)
             if db_id not in LDB_DBS:
                 directory = self._root_directory.join(db_id)
-                LDB_DBS[db_id] = get_ldb(directory)
+                LDB_DBS[db_id] = open_ldb(directory)
 
     def flushall(self):
         for db_id_ in range(NUMBER_OF_REDIS_DATABASES):
@@ -40,12 +40,12 @@ class DiskKeyspace(object):
             directory = self._root_directory.join(db_id)
             LDB_DBS[db_id].close()
             directory.reset()
-            LDB_DBS[db_id] = get_ldb(directory)
+            LDB_DBS[db_id] = open_ldb(directory)
 
     def flushdb(self):
         self._ldb.close()
         self.directory.reset()
-        self._ldb = get_ldb(self.directory)
+        self._ldb = open_ldb(self.directory)
 
     def select(self, db):
         self._set_db(db)

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -1,7 +1,7 @@
 import collections
 import fnmatch
 
-from dredis.ldb import LDB_DBS, LDB_KEY_TYPES, LDB_MIN_ZSET_SCORE, KEY_CODEC, get_ldb
+from dredis.ldb import LDB_DBS, LDB_KEY_TYPES, KEY_CODEC, get_ldb
 from dredis.lua import LuaRunner
 from dredis.path import Path
 from dredis.utils import to_float
@@ -122,7 +122,7 @@ class DiskKeyspace(object):
                 result += 1
             elif self._ldb.get(KEY_CODEC.encode_zset(key)) is not None:
                 self._ldb.delete(KEY_CODEC.encode_zset(key))
-                min_key = KEY_CODEC.encode_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
+                min_key = KEY_CODEC.get_min_zset_score(key)
                 for db_key, _ in self._ldb.iterator(start=min_key, include_start=True):
                     self._ldb.delete(db_key)
                 result += 1
@@ -178,7 +178,7 @@ class DiskKeyspace(object):
             begin = max(0, zset_length + start)
         else:
             begin = start
-        min_key = KEY_CODEC.encode_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
+        min_key = KEY_CODEC.get_min_zset_score(key)
         for i, (db_key, _) in enumerate(self._ldb.iterator(start=min_key, include_start=True)):
             if i < begin:
                 continue
@@ -232,7 +232,7 @@ class DiskKeyspace(object):
             num_elems_per_entry = 1
 
         score_range = ScoreRange(min_score, max_score)
-        min_key = KEY_CODEC.encode_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
+        min_key = KEY_CODEC.get_min_zset_score(key)
         for db_key, _ in self._ldb.iterator(start=min_key, include_start=True):
             db_score = KEY_CODEC.decode_zset_score(db_key)
             db_value = KEY_CODEC.decode_zset_value(db_key)
@@ -257,7 +257,7 @@ class DiskKeyspace(object):
         #     zset_6_myzset_10 = 2
 
         score_range = ScoreRange(min_score, max_score)
-        min_key = KEY_CODEC.encode_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
+        min_key = KEY_CODEC.get_min_zset_score(key)
         count = 0
         for db_key, _ in self._ldb.iterator(start=min_key, include_start=True):
             db_score = KEY_CODEC.decode_zset_score(db_key)
@@ -272,7 +272,7 @@ class DiskKeyspace(object):
         if score is None:
             return None
 
-        min_key = KEY_CODEC.encode_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
+        min_key = KEY_CODEC.get_min_zset_score(key)
         rank = 0
         for db_key, _ in self._ldb.iterator(start=min_key, include_start=True):
             db_score = KEY_CODEC.decode_zset_score(db_key)

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -23,8 +23,7 @@ class Keyspace(object):
         self._set_db(self._current_db)
 
     def _set_db(self, db):
-        db = str(db)
-        self._current_db = db
+        self._current_db = str(db)
 
     def flushall(self):
         LEVELDB.delete_dbs()

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -487,12 +487,11 @@ class DiskKeyspace(object):
         return result
 
     def hlen(self, key):
-        key_path = self._key_path(key)
-        fields_path = key_path.join('fields')
-        result = 0
-        if fields_path.exists():
-            result = len(fields_path.listdir())
-        return result
+        result = self._ldb.get(encode_ldb_key_hash(key))
+        if result is None:
+            return 0
+        else:
+            return int(result)
 
     def hincrby(self, key, field, increment):
         before = self.hget(key, field) or '0'

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -322,7 +322,7 @@ class DiskKeyspace(object):
         return self.directory.listdir(pattern)
 
     def dbsize(self):
-        return len(self.directory.listdir())
+        return len(self.keys(pattern=None))
 
     def exists(self, *keys):
         result = 0

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -147,11 +147,7 @@ class DiskKeyspace(object):
         return result
 
     def sismember(self, key, value):
-        key_path = self._key_path(key)
-        values_path = key_path.join('values')
-        fname = self._get_filename_hash(value)
-        value_path = values_path.join(fname)
-        return value_path.exists()
+        return self._ldb.get(encode_ldb_key_set_member(key, value)) is not None
 
     def scard(self, key):
         return len(self.smembers(key))

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -154,10 +154,15 @@ class DiskKeyspace(object):
             key_path = self._key_path(key)
             if key_path.exists():
                 key_path.delete()
+                result += 1
 
-            if self.get(key):
+            if self._ldb.get(encode_ldb_key_string(key)) is not None:
                 self._ldb.delete(encode_ldb_key_string(key))
                 result += 1
+            elif self._ldb.get(encode_ldb_key_set(key)) is not None:
+                self._ldb.delete(encode_ldb_key_set(key))
+                result += 1
+
         return result
 
     def zadd(self, key, score, value):

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -39,17 +39,11 @@ class DiskKeyspace(object):
         self._set_db_directory(db)
 
     def incrby(self, key, increment=1):
-        key_path = self._key_path(key)
-        value_path = key_path.join('value')
-        number = 0
-        if self.exists(key):
-            content = value_path.read()
-            number = int(content)
-        else:
-            key_path.makedirs()
-            self.write_type(key, 'string')
-        result = number + increment
-        value_path.write(str(result))
+        number = self.get(key)
+        if number is None:
+            number = '0'
+        result = int(number) + increment
+        self.set(key, str(result))
         return result
 
     def get(self, key):

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -24,9 +24,6 @@ class DiskKeyspace(object):
         self._current_db = db
         self.directory = self._root_directory.join(db)
 
-    def _key_path(self, key):
-        return self.directory.join(key)
-
     def _setup_dbs(self):
         for db_id_ in range(NUMBER_OF_REDIS_DATABASES):
             db_id = str(db_id_)

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -10,7 +10,7 @@ DEFAULT_REDIS_DB = '0'
 NUMBER_OF_REDIS_DATABASES = 16
 
 
-class DiskKeyspace(object):
+class Keyspace(object):
 
     def __init__(self, root_dir):
         self._lua_runner = LuaRunner(self)

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -395,14 +395,14 @@ class DiskKeyspace(object):
         return 'none'
 
     def keys(self, pattern):
-        level_db_keys = []
+        level_db_keys = set()
         for key, _ in self._ldb:
             key_type, _, key_value = decode_ldb_key(key)
             if key_type not in LDB_KEY_TYPES:
                 continue
             if pattern is None or fnmatch.fnmatch(key_value, pattern):
-                level_db_keys.append(key_value)
-        return set(self.directory.listdir(pattern) + level_db_keys)
+                level_db_keys.add(key_value)
+        return level_db_keys
 
     def dbsize(self):
         return len(self.keys(pattern=None))

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -1,7 +1,7 @@
 import collections
 import fnmatch
 
-from dredis.ldb import LDB_DBS, LDB_KEY_TYPES, KEY_CODEC, flush_ldb, get_ldb
+from dredis.ldb import LEVELDB, LDB_KEY_TYPES, KEY_CODEC
 from dredis.lua import LuaRunner
 from dredis.utils import to_float
 
@@ -21,11 +21,10 @@ class Keyspace(object):
         self._current_db = db
 
     def flushall(self):
-        for db_id in LDB_DBS:
-            flush_ldb(db_id)
+        LEVELDB.delete_dbs()
 
     def flushdb(self):
-        flush_ldb(self._current_db)
+        LEVELDB.delete_db(self._current_db)
 
     def select(self, db):
         self._set_db(db)
@@ -396,7 +395,7 @@ class Keyspace(object):
 
     @property
     def _ldb(self):
-        return get_ldb(self._current_db)
+        return LEVELDB.get_db(self._current_db)
 
 
 class ScoreRange(object):

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -107,17 +107,12 @@ class Keyspace(object):
     def _delete_ldb_string(self, key):
         # there is one set of ldb keys for strings:
         # * string
-        # example:
-        #     <key prefix>|<key length>|<key>
         self._ldb.delete(KEY_CODEC.encode_string(key))
 
     def _delete_ldb_set(self, key):
         # there are two sets of ldb keys for sets:
         # * set
         # * set members
-        # example:
-        #     <key prefix>|<key length>|<key>
-        #     <set member prefix>|<key length>|<key>|<member>
         with self._ldb.write_batch() as batch:
             batch.delete(KEY_CODEC.encode_set(key))
             for db_key, _ in self._get_ldb_prefix_iterator(KEY_CODEC.get_min_set_member(key)):
@@ -127,9 +122,6 @@ class Keyspace(object):
         # there are two sets of ldb keys for hashes:
         # * hash
         # * hash fields
-        # example:
-        #     <key prefix>|<key length>|<key>
-        #     <hash field prefix>|<key length>|<key>|<field>
         with self._ldb.write_batch() as batch:
             batch.delete(KEY_CODEC.encode_hash(key))
             for db_key, _ in self._get_ldb_prefix_iterator(KEY_CODEC.get_min_hash_field(key)):
@@ -140,10 +132,6 @@ class Keyspace(object):
         # * zset
         # * zset scores
         # * zset values
-        # example:
-        #     <key prefix>|<key length>|<key>
-        #     <zset value prefix>|<key length>|<key>|<value>
-        #     <zset score prefix>|<key length>|<key>|<score><value>
         with self._ldb.write_batch() as batch:
             batch.delete(KEY_CODEC.encode_zset(key))
             for db_key, _ in self._get_ldb_prefix_iterator(KEY_CODEC.get_min_zset_score(key)):

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -150,7 +150,11 @@ class DiskKeyspace(object):
         return self._ldb.get(encode_ldb_key_set_member(key, value)) is not None
 
     def scard(self, key):
-        return len(self.smembers(key))
+        length = self._ldb.get(encode_ldb_key_set(key))
+        if length is None:
+            return 0
+        else:
+            return int(length)
 
     def delete(self, *keys):
         result = 0

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -1,87 +1,13 @@
 import collections
 import fnmatch
-import struct
 
-import plyvel
-
+from dredis.ldb import LDB_DBS, LDB_KEY_TYPES, LDB_MIN_ZSET_SCORE, KEY_CODEC, get_ldb
 from dredis.lua import LuaRunner
 from dredis.path import Path
 from dredis.utils import to_float
 
 DEFAULT_REDIS_DB = '0'
 NUMBER_OF_REDIS_DATABASES = 15
-
-
-LDB_DBS = {}
-
-LDB_STRING_TYPE = 1
-LDB_SET_TYPE = 2
-LDB_SET_MEMBER_TYPE = 3
-LDB_HASH_TYPE = 4
-LDB_HASH_FIELD_TYPE = 5
-LDB_ZSET_TYPE = 6
-LDB_ZSET_VALUE_TYPE = 7
-LDB_ZSET_SCORE_TYPE = 8
-
-LDB_KEY_TYPES = [LDB_STRING_TYPE, LDB_SET_TYPE, LDB_HASH_TYPE, LDB_ZSET_TYPE]
-
-# type_id | key_length
-LDB_KEY_PREFIX_FORMAT = '>BI'
-LDB_KEY_PREFIX_LENGTH = struct.calcsize(LDB_KEY_PREFIX_FORMAT)
-
-LDB_ZSET_SCORE_FORMAT = '>d'
-# ldb sorts elements lexicographically and negative numbers
-# when converted to binary are "bigger" than positives.
-# zero is the lowest byte combination.
-LDB_MIN_ZSET_SCORE = 0
-
-
-class LDBKeyCodec(object):
-
-    def get_key(self, key, type_id):
-        prefix = struct.pack(LDB_KEY_PREFIX_FORMAT, type_id, len(key))
-        return prefix + bytes(key)
-
-    def encode_string(self, key):
-        return self.get_key(key, LDB_STRING_TYPE)
-
-    def encode_set(self, key):
-        return self.get_key(key, LDB_SET_TYPE)
-
-    def encode_set_member(self, key, value):
-        return self.get_key(key, LDB_SET_MEMBER_TYPE) + bytes(value)
-
-    def encode_hash(self, key):
-        return self.get_key(key, LDB_HASH_TYPE)
-
-    def encode_hash_field(self, key, field):
-        return self.get_key(key, LDB_HASH_FIELD_TYPE) + bytes(field)
-
-    def encode_zset(self, key):
-        return self.get_key(key, LDB_ZSET_TYPE)
-
-    def encode_zset_value(self, key, value):
-        return self.get_key(key, LDB_ZSET_VALUE_TYPE) + bytes(value)
-
-    def encode_zset_score(self, key, value, score):
-        return self.get_key(key, LDB_ZSET_SCORE_TYPE) + struct.pack(LDB_ZSET_SCORE_FORMAT, float(score)) + bytes(value)
-
-    def decode_key(self, key):
-        type_id, key_length = struct.unpack(LDB_KEY_PREFIX_FORMAT, key[:LDB_KEY_PREFIX_LENGTH])
-        key_value = key[LDB_KEY_PREFIX_LENGTH:]
-        return type_id, key_length, key_value
-
-    def decode_zset_score(self, ldb_key):
-        _, length, key_name = self.decode_key(ldb_key)
-        return struct.unpack(LDB_ZSET_SCORE_FORMAT, key_name[length:length + struct.calcsize(LDB_ZSET_SCORE_FORMAT)])[0]
-
-    def decode_zset_value(self, ldb_key):
-        _, length, key_name = self.decode_key(ldb_key)
-        return key_name[length + struct.calcsize(LDB_ZSET_SCORE_FORMAT):]
-
-
-KEY_CODEC = LDBKeyCodec()
-
 
 
 class DiskKeyspace(object):
@@ -104,23 +30,22 @@ class DiskKeyspace(object):
     def _setup_dbs(self):
         for db_id_ in range(NUMBER_OF_REDIS_DATABASES):
             db_id = str(db_id_)
-            ldb_directory = bytes(self._root_directory.join(db_id))
             if db_id not in LDB_DBS:
-                LDB_DBS[db_id] = plyvel.DB(ldb_directory, create_if_missing=True)
+                directory = self._root_directory.join(db_id)
+                LDB_DBS[db_id] = get_ldb(directory)
 
     def flushall(self):
         for db_id_ in range(NUMBER_OF_REDIS_DATABASES):
             db_id = str(db_id_)
-            ldb_directory = bytes(self._root_directory.join(db_id))
+            directory = self._root_directory.join(db_id)
             LDB_DBS[db_id].close()
-            Path(ldb_directory).reset()
-            LDB_DBS[db_id] = plyvel.DB(ldb_directory, create_if_missing=True)
+            directory.reset()
+            LDB_DBS[db_id] = get_ldb(directory)
 
     def flushdb(self):
-        ldb_directory = bytes(self.directory)
         self._ldb.close()
-        Path(ldb_directory).reset()
-        self._ldb = plyvel.DB(ldb_directory, create_if_missing=True)
+        self.directory.reset()
+        self._ldb = get_ldb(self.directory)
 
     def select(self, db):
         self._set_db(db)

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -7,7 +7,7 @@ from dredis.path import Path
 from dredis.utils import to_float
 
 DEFAULT_REDIS_DB = '0'
-NUMBER_OF_REDIS_DATABASES = 15
+NUMBER_OF_REDIS_DATABASES = 16
 
 
 class DiskKeyspace(object):

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -38,45 +38,45 @@ LDB_MIN_ZSET_SCORE = 0
 
 class LDBKeyCodec(object):
 
-    def get_ldb_key(self, key, type_id):
+    def get_key(self, key, type_id):
         prefix = struct.pack(LDB_KEY_PREFIX_FORMAT, type_id, len(key))
         return prefix + bytes(key)
 
-    def encode_ldb_key_string(self, key):
-        return self.get_ldb_key(key, LDB_STRING_TYPE)
+    def encode_string(self, key):
+        return self.get_key(key, LDB_STRING_TYPE)
 
-    def encode_ldb_key_set(self, key):
-        return self.get_ldb_key(key, LDB_SET_TYPE)
+    def encode_set(self, key):
+        return self.get_key(key, LDB_SET_TYPE)
 
-    def encode_ldb_key_set_member(self, key, value):
-        return self.get_ldb_key(key, LDB_SET_MEMBER_TYPE) + bytes(value)
+    def encode_set_member(self, key, value):
+        return self.get_key(key, LDB_SET_MEMBER_TYPE) + bytes(value)
 
-    def encode_ldb_key_hash(self, key):
-        return self.get_ldb_key(key, LDB_HASH_TYPE)
+    def encode_hash(self, key):
+        return self.get_key(key, LDB_HASH_TYPE)
 
-    def encode_ldb_key_hash_field(self, key, field):
-        return self.get_ldb_key(key, LDB_HASH_FIELD_TYPE) + bytes(field)
+    def encode_hash_field(self, key, field):
+        return self.get_key(key, LDB_HASH_FIELD_TYPE) + bytes(field)
 
-    def encode_ldb_key_zset(self, key):
-        return self.get_ldb_key(key, LDB_ZSET_TYPE)
+    def encode_zset(self, key):
+        return self.get_key(key, LDB_ZSET_TYPE)
 
-    def encode_ldb_key_zset_value(self, key, value):
-        return self.get_ldb_key(key, LDB_ZSET_VALUE_TYPE) + bytes(value)
+    def encode_zset_value(self, key, value):
+        return self.get_key(key, LDB_ZSET_VALUE_TYPE) + bytes(value)
 
-    def encode_ldb_key_zset_score(self, key, value, score):
-        return self.get_ldb_key(key, LDB_ZSET_SCORE_TYPE) + struct.pack('>d', float(score)) + bytes(value)
+    def encode_zset_score(self, key, value, score):
+        return self.get_key(key, LDB_ZSET_SCORE_TYPE) + struct.pack(LDB_ZSET_SCORE_FORMAT, float(score)) + bytes(value)
 
-    def decode_ldb_key(self, key):
+    def decode_key(self, key):
         type_id, key_length = struct.unpack(LDB_KEY_PREFIX_FORMAT, key[:LDB_KEY_PREFIX_LENGTH])
         key_value = key[LDB_KEY_PREFIX_LENGTH:]
         return type_id, key_length, key_value
 
-    def decode_ldb_key_zset_score(self, ldb_key):
-        _, length, key_name = self.decode_ldb_key(ldb_key)
+    def decode_zset_score(self, ldb_key):
+        _, length, key_name = self.decode_key(ldb_key)
         return struct.unpack(LDB_ZSET_SCORE_FORMAT, key_name[length:length + struct.calcsize(LDB_ZSET_SCORE_FORMAT)])[0]
 
-    def decode_ldb_key_zset_value(self, ldb_key):
-        _, length, key_name = self.decode_ldb_key(ldb_key)
+    def decode_zset_value(self, ldb_key):
+        _, length, key_name = self.decode_key(ldb_key)
         return key_name[length + struct.calcsize(LDB_ZSET_SCORE_FORMAT):]
 
 
@@ -134,10 +134,10 @@ class DiskKeyspace(object):
         return result
 
     def get(self, key):
-        return self._ldb.get(KEY_CODEC.encode_ldb_key_string(key))
+        return self._ldb.get(KEY_CODEC.encode_string(key))
 
     def set(self, key, value):
-        self._ldb.put(KEY_CODEC.encode_ldb_key_string(key), value)
+        self._ldb.put(KEY_CODEC.encode_string(key), value)
 
     def getrange(self, key, start, end):
         value = self.get(key)
@@ -150,30 +150,30 @@ class DiskKeyspace(object):
             return value[start:end]
 
     def sadd(self, key, value):
-        if self._ldb.get(KEY_CODEC.encode_ldb_key_set_member(key, value)) is None:
-            length = int(self._ldb.get(KEY_CODEC.encode_ldb_key_set(key)) or b'0')
-            self._ldb.put(KEY_CODEC.encode_ldb_key_set(key), bytes(length + 1))
-            self._ldb.put(KEY_CODEC.encode_ldb_key_set_member(key, value), bytes(''))
+        if self._ldb.get(KEY_CODEC.encode_set_member(key, value)) is None:
+            length = int(self._ldb.get(KEY_CODEC.encode_set(key)) or b'0')
+            self._ldb.put(KEY_CODEC.encode_set(key), bytes(length + 1))
+            self._ldb.put(KEY_CODEC.encode_set_member(key, value), bytes(''))
             return 1
         else:
             return 0
 
     def smembers(self, key):
         result = set()
-        if self._ldb.get(KEY_CODEC.encode_ldb_key_set(key)):
+        if self._ldb.get(KEY_CODEC.encode_set(key)):
             # the empty string marks the beginning of the members
-            member_start = KEY_CODEC.encode_ldb_key_set_member(key, bytes(''))
+            member_start = KEY_CODEC.encode_set_member(key, bytes(''))
             for db_key, db_value in self._ldb.iterator(start=member_start, include_start=False):
-                _, length, member_key = KEY_CODEC.decode_ldb_key(db_key)
+                _, length, member_key = KEY_CODEC.decode_key(db_key)
                 member_value = member_key[length:]
                 result.add(member_value)
         return result
 
     def sismember(self, key, value):
-        return self._ldb.get(KEY_CODEC.encode_ldb_key_set_member(key, value)) is not None
+        return self._ldb.get(KEY_CODEC.encode_set_member(key, value)) is not None
 
     def scard(self, key):
-        length = self._ldb.get(KEY_CODEC.encode_ldb_key_set(key))
+        length = self._ldb.get(KEY_CODEC.encode_set(key))
         if length is None:
             return 0
         else:
@@ -182,22 +182,22 @@ class DiskKeyspace(object):
     def delete(self, *keys):
         result = 0
         for key in keys:
-            if self._ldb.get(KEY_CODEC.encode_ldb_key_string(key)) is not None:
-                self._ldb.delete(KEY_CODEC.encode_ldb_key_string(key))
+            if self._ldb.get(KEY_CODEC.encode_string(key)) is not None:
+                self._ldb.delete(KEY_CODEC.encode_string(key))
                 result += 1
-            elif self._ldb.get(KEY_CODEC.encode_ldb_key_set(key)) is not None:
-                self._ldb.delete(KEY_CODEC.encode_ldb_key_set(key))
+            elif self._ldb.get(KEY_CODEC.encode_set(key)) is not None:
+                self._ldb.delete(KEY_CODEC.encode_set(key))
                 for member in self.smembers(key):
-                    self._ldb.delete(KEY_CODEC.encode_ldb_key_set_member(key, member))
+                    self._ldb.delete(KEY_CODEC.encode_set_member(key, member))
                 result += 1
-            elif self._ldb.get(KEY_CODEC.encode_ldb_key_hash(key)) is not None:
-                self._ldb.delete(KEY_CODEC.encode_ldb_key_hash(key))
+            elif self._ldb.get(KEY_CODEC.encode_hash(key)) is not None:
+                self._ldb.delete(KEY_CODEC.encode_hash(key))
                 for field in self.hkeys(key):
-                    self._ldb.delete(KEY_CODEC.encode_ldb_key_hash_field(key, field))
+                    self._ldb.delete(KEY_CODEC.encode_hash_field(key, field))
                 result += 1
-            elif self._ldb.get(KEY_CODEC.encode_ldb_key_zset(key)) is not None:
-                self._ldb.delete(KEY_CODEC.encode_ldb_key_zset(key))
-                min_key = KEY_CODEC.encode_ldb_key_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
+            elif self._ldb.get(KEY_CODEC.encode_zset(key)) is not None:
+                self._ldb.delete(KEY_CODEC.encode_zset(key))
+                min_key = KEY_CODEC.encode_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
                 for db_key, _ in self._ldb.iterator(start=min_key, include_start=True):
                     self._ldb.delete(db_key)
                 result += 1
@@ -220,30 +220,30 @@ class DiskKeyspace(object):
         zset_6_myzset_7_value_world = 10
         zset_6_myzset_8_world = ''
         """
-        zset_length = int(self._ldb.get(KEY_CODEC.encode_ldb_key_zset(key), '0'))
+        zset_length = int(self._ldb.get(KEY_CODEC.encode_zset(key), '0'))
 
-        db_score = self._ldb.get(KEY_CODEC.encode_ldb_key_zset_value(key, value))
+        db_score = self._ldb.get(KEY_CODEC.encode_zset_value(key, value))
         if db_score is not None:
             result = 0
             previous_score = db_score
             if float(previous_score) == float(score):
                 return result
             else:
-                self._ldb.delete(KEY_CODEC.encode_ldb_key_zset_score(key, value, previous_score))
+                self._ldb.delete(KEY_CODEC.encode_zset_score(key, value, previous_score))
         else:
             result = 1
             zset_length += 1
 
-        self._ldb.put(KEY_CODEC.encode_ldb_key_zset(key), bytes(zset_length))
-        self._ldb.put(KEY_CODEC.encode_ldb_key_zset_value(key, value), bytes(score))
-        self._ldb.put(KEY_CODEC.encode_ldb_key_zset_score(key, value, score), bytes(''))
+        self._ldb.put(KEY_CODEC.encode_zset(key), bytes(zset_length))
+        self._ldb.put(KEY_CODEC.encode_zset_value(key, value), bytes(score))
+        self._ldb.put(KEY_CODEC.encode_zset_score(key, value, score), bytes(''))
 
         return result
 
     def zrange(self, key, start, stop, with_scores):
         result = []
 
-        zset_length = int(self._ldb.get(KEY_CODEC.encode_ldb_key_zset(key), '0'))
+        zset_length = int(self._ldb.get(KEY_CODEC.encode_zset(key), '0'))
         if stop < 0:
             end = zset_length + stop
         else:
@@ -253,14 +253,14 @@ class DiskKeyspace(object):
             begin = max(0, zset_length + start)
         else:
             begin = start
-        min_key = KEY_CODEC.encode_ldb_key_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
+        min_key = KEY_CODEC.encode_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
         for i, (db_key, _) in enumerate(self._ldb.iterator(start=min_key, include_start=True)):
             if i < begin:
                 continue
             if i > end:
                 break
-            db_score = KEY_CODEC.decode_ldb_key_zset_score(db_key)
-            db_value = KEY_CODEC.decode_ldb_key_zset_value(db_key)
+            db_score = KEY_CODEC.decode_zset_score(db_key)
+            db_value = KEY_CODEC.decode_zset_value(db_key)
             result.append(db_value)
             if with_scores:
                 result.append(str(db_score))
@@ -268,10 +268,10 @@ class DiskKeyspace(object):
         return result
 
     def zcard(self, key):
-        return int(self._ldb.get(KEY_CODEC.encode_ldb_key_zset(key), '0'))
+        return int(self._ldb.get(KEY_CODEC.encode_zset(key), '0'))
 
     def zscore(self, key, member):
-        return self._ldb.get(KEY_CODEC.encode_ldb_key_zset_value(key, member))
+        return self._ldb.get(KEY_CODEC.encode_zset_value(key, member))
 
     def eval(self, script, keys, argv):
         return self._lua_runner.run(script, keys, argv)
@@ -281,21 +281,21 @@ class DiskKeyspace(object):
         see zadd() for information about score and value structures
         """
         result = 0
-        zset_length = int(self._ldb.get(KEY_CODEC.encode_ldb_key_zset(key), '0'))
+        zset_length = int(self._ldb.get(KEY_CODEC.encode_zset(key), '0'))
         for member in members:
-            score = self._ldb.get(KEY_CODEC.encode_ldb_key_zset_value(key, member))
+            score = self._ldb.get(KEY_CODEC.encode_zset_value(key, member))
             if score is None:
                 continue
             result += 1
             zset_length -= 1
-            self._ldb.delete(KEY_CODEC.encode_ldb_key_zset_value(key, member))
-            self._ldb.delete(KEY_CODEC.encode_ldb_key_zset_score(key, member, score))
+            self._ldb.delete(KEY_CODEC.encode_zset_value(key, member))
+            self._ldb.delete(KEY_CODEC.encode_zset_score(key, member, score))
 
         # empty zset should be removed from keyspace
         if zset_length == 0:
             self.delete(key)
         else:
-            self._ldb.put(KEY_CODEC.encode_ldb_key_zset(key), bytes(zset_length))
+            self._ldb.put(KEY_CODEC.encode_zset(key), bytes(zset_length))
         return result
 
     def zrangebyscore(self, key, min_score, max_score, withscores=False, offset=0, count=float('+inf')):
@@ -307,10 +307,10 @@ class DiskKeyspace(object):
             num_elems_per_entry = 1
 
         score_range = ScoreRange(min_score, max_score)
-        min_key = KEY_CODEC.encode_ldb_key_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
+        min_key = KEY_CODEC.encode_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
         for db_key, _ in self._ldb.iterator(start=min_key, include_start=True):
-            db_score = KEY_CODEC.decode_ldb_key_zset_score(db_key)
-            db_value = KEY_CODEC.decode_ldb_key_zset_value(db_key)
+            db_score = KEY_CODEC.decode_zset_score(db_key)
+            db_value = KEY_CODEC.decode_zset_value(db_key)
             if score_range.above_max(db_score):
                 break
             if score_range.check(db_score):
@@ -332,10 +332,10 @@ class DiskKeyspace(object):
         #     zset_6_myzset_10 = 2
 
         score_range = ScoreRange(min_score, max_score)
-        min_key = KEY_CODEC.encode_ldb_key_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
+        min_key = KEY_CODEC.encode_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
         count = 0
         for db_key, _ in self._ldb.iterator(start=min_key, include_start=True):
-            db_score = KEY_CODEC.decode_ldb_key_zset_score(db_key)
+            db_score = KEY_CODEC.decode_zset_score(db_key)
             if score_range.check(db_score):
                 count += 1
             if score_range.above_max(db_score):
@@ -343,15 +343,15 @@ class DiskKeyspace(object):
         return count
 
     def zrank(self, key, member):
-        score = self._ldb.get(KEY_CODEC.encode_ldb_key_zset_value(key, member))
+        score = self._ldb.get(KEY_CODEC.encode_zset_value(key, member))
         if score is None:
             return None
 
-        min_key = KEY_CODEC.encode_ldb_key_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
+        min_key = KEY_CODEC.encode_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
         rank = 0
         for db_key, _ in self._ldb.iterator(start=min_key, include_start=True):
-            db_score = KEY_CODEC.decode_ldb_key_zset_score(db_key)
-            db_value = KEY_CODEC.decode_ldb_key_zset_value(db_key)
+            db_score = KEY_CODEC.decode_zset_score(db_key)
+            db_value = KEY_CODEC.decode_zset_value(db_key)
             if db_score < float(score):
                 rank += 1
             elif db_score == float(score) and db_value < member:
@@ -377,20 +377,20 @@ class DiskKeyspace(object):
         return result
 
     def type(self, key):
-        if self._ldb.get(KEY_CODEC.encode_ldb_key_string(key)):
+        if self._ldb.get(KEY_CODEC.encode_string(key)):
             return 'string'
-        if self._ldb.get(KEY_CODEC.encode_ldb_key_set(key)):
+        if self._ldb.get(KEY_CODEC.encode_set(key)):
             return 'set'
-        if self._ldb.get(KEY_CODEC.encode_ldb_key_hash(key)):
+        if self._ldb.get(KEY_CODEC.encode_hash(key)):
             return 'hash'
-        if self._ldb.get(KEY_CODEC.encode_ldb_key_zset(key)):
+        if self._ldb.get(KEY_CODEC.encode_zset(key)):
             return 'zset'
         return 'none'
 
     def keys(self, pattern):
         level_db_keys = set()
         for key, _ in self._ldb:
-            key_type, _, key_value = KEY_CODEC.decode_ldb_key(key)
+            key_type, _, key_value = KEY_CODEC.decode_key(key)
             if key_type not in LDB_KEY_TYPES:
                 continue
             if pattern is None or fnmatch.fnmatch(key_value, pattern):
@@ -409,50 +409,50 @@ class DiskKeyspace(object):
 
     def hset(self, key, field, value):
         result = 0
-        if self._ldb.get(KEY_CODEC.encode_ldb_key_hash_field(key, field)) is None:
+        if self._ldb.get(KEY_CODEC.encode_hash_field(key, field)) is None:
             result = 1
-        hash_length = int(self._ldb.get(KEY_CODEC.encode_ldb_key_hash(key), '0'))
-        self._ldb.put(KEY_CODEC.encode_ldb_key_hash(key), bytes(hash_length + 1))
-        self._ldb.put(KEY_CODEC.encode_ldb_key_hash_field(key, field), value)
+        hash_length = int(self._ldb.get(KEY_CODEC.encode_hash(key), '0'))
+        self._ldb.put(KEY_CODEC.encode_hash(key), bytes(hash_length + 1))
+        self._ldb.put(KEY_CODEC.encode_hash_field(key, field), value)
         return result
 
     def hsetnx(self, key, field, value):
         # only set if not set before
-        if self._ldb.get(KEY_CODEC.encode_ldb_key_hash_field(key, field)) is None:
-            hash_length = int(self._ldb.get(KEY_CODEC.encode_ldb_key_hash(key), '0'))
-            self._ldb.put(KEY_CODEC.encode_ldb_key_hash(key), bytes(hash_length + 1))
-            self._ldb.put(KEY_CODEC.encode_ldb_key_hash_field(key, field), value)
+        if self._ldb.get(KEY_CODEC.encode_hash_field(key, field)) is None:
+            hash_length = int(self._ldb.get(KEY_CODEC.encode_hash(key), '0'))
+            self._ldb.put(KEY_CODEC.encode_hash(key), bytes(hash_length + 1))
+            self._ldb.put(KEY_CODEC.encode_hash_field(key, field), value)
             return 1
         else:
             return 0
 
     def hdel(self, key, *fields):
         result = 0
-        hash_length = int(self._ldb.get(KEY_CODEC.encode_ldb_key_hash(key), '0'))
+        hash_length = int(self._ldb.get(KEY_CODEC.encode_hash(key), '0'))
 
         for field in fields:
-            if self._ldb.get(KEY_CODEC.encode_ldb_key_hash_field(key, field)) is not None:
+            if self._ldb.get(KEY_CODEC.encode_hash_field(key, field)) is not None:
                 result += 1
                 hash_length -= 1
-                self._ldb.delete(KEY_CODEC.encode_ldb_key_hash_field(key, field))
+                self._ldb.delete(KEY_CODEC.encode_hash_field(key, field))
 
         if hash_length == 0:
             # remove empty hashes from keyspace
             self.delete(key)
         else:
-            self._ldb.put(KEY_CODEC.encode_ldb_key_hash(key), bytes(hash_length))
+            self._ldb.put(KEY_CODEC.encode_hash(key), bytes(hash_length))
         return result
 
     def hget(self, key, field):
-        return self._ldb.get(KEY_CODEC.encode_ldb_key_hash_field(key, field))
+        return self._ldb.get(KEY_CODEC.encode_hash_field(key, field))
 
     def hkeys(self, key):
         result = []
-        if self._ldb.get(KEY_CODEC.encode_ldb_key_hash(key)) is not None:
+        if self._ldb.get(KEY_CODEC.encode_hash(key)) is not None:
             # the empty string marks the beginning of the fields
-            field_start = KEY_CODEC.encode_ldb_key_hash_field(key, bytes(''))
+            field_start = KEY_CODEC.encode_hash_field(key, bytes(''))
             for db_key, db_value in self._ldb.iterator(start=field_start, include_start=False):
-                _, length, field_key = KEY_CODEC.decode_ldb_key(db_key)
+                _, length, field_key = KEY_CODEC.decode_key(db_key)
                 field = field_key[length:]
                 result.append(field)
 
@@ -460,15 +460,15 @@ class DiskKeyspace(object):
 
     def hvals(self, key):
         result = []
-        if self._ldb.get(KEY_CODEC.encode_ldb_key_hash(key)) is not None:
+        if self._ldb.get(KEY_CODEC.encode_hash(key)) is not None:
             # the empty string marks the beginning of the fields
-            field_start = KEY_CODEC.encode_ldb_key_hash_field(key, bytes(''))
+            field_start = KEY_CODEC.encode_hash_field(key, bytes(''))
             for db_key, db_value in self._ldb.iterator(start=field_start, include_start=False):
                 result.append(db_value)
         return result
 
     def hlen(self, key):
-        result = self._ldb.get(KEY_CODEC.encode_ldb_key_hash(key))
+        result = self._ldb.get(KEY_CODEC.encode_hash(key))
         if result is None:
             return 0
         else:

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -159,21 +159,6 @@ class Keyspace(object):
                 break
 
     def zadd(self, key, score, value):
-        """
-        This is an example of how sorted sets are stored on leveldb
-
-        zadd myzset 10 "hello"
-        zadd myzset 10 "world"
-        zadd myzset 11 "hello"
-
-        KEY_zset_6_myzset = 2
-
-        ZSETVALUE_zset_6_myzset_7_hello = 10
-        ZSETSCORE_zset_6_myzset_8_10_hello = ''
-
-        ZSETVALUE_zset_6_myzset_7_value_world = 10
-        ZSETSCORE_zset_6_myzset_8_world = ''
-        """
         zset_length = int(self._ldb.get(KEY_CODEC.encode_zset(key), '0'))
 
         db_score = self._ldb.get(KEY_CODEC.encode_zset_value(key, value))

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -257,10 +257,13 @@ class Keyspace(object):
     def zcount(self, key, min_score, max_score):
         # TODO: optimize for performance. it's probably possible to create a new entry only for scores
         # like:
-        #     zadd myzset 10 a
-        #     zset_6_myzset_10 = 1
-        #     zadd myzset 10 b
-        #     zset_6_myzset_10 = 2
+        #     <prefix>myzset<score> = number of elements with that score
+        #
+        #     ZADD myzset 10 a
+        #     <prefix>_myzset_10 = 1  ; one element with score 10
+        #
+        #     ZADD myzset 10 b
+        #     <prefix>_myzset_10 = 2  ; two elements with score 10
 
         score_range = ScoreRange(min_score, max_score)
         count = 0

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -109,22 +109,20 @@ class DiskKeyspace(object):
     def _setup_dbs(self):
         for db_id_ in range(NUMBER_OF_REDIS_DATABASES):
             db_id = str(db_id_)
-            directory = self._root_directory.join(db_id)
-            ldb_directory = bytes(directory + "-leveldb")
+            ldb_directory = bytes(self._root_directory.join(db_id))
             if db_id not in LDB_DBS:
                 LDB_DBS[db_id] = plyvel.DB(ldb_directory, create_if_missing=True)
 
     def flushall(self):
         for db_id_ in range(NUMBER_OF_REDIS_DATABASES):
             db_id = str(db_id_)
-            directory = self._root_directory.join(db_id)
-            ldb_directory = bytes(directory + "-leveldb")
+            ldb_directory = bytes(self._root_directory.join(db_id))
             LDB_DBS[db_id].close()
             Path(ldb_directory).reset()
             LDB_DBS[db_id] = plyvel.DB(ldb_directory, create_if_missing=True)
 
     def flushdb(self):
-        ldb_directory = bytes(self.directory + "-leveldb")
+        ldb_directory = bytes(self.directory)
         self._ldb.close()
         Path(ldb_directory).reset()
         self._ldb = plyvel.DB(ldb_directory, create_if_missing=True)

--- a/dredis/ldb.py
+++ b/dredis/ldb.py
@@ -20,11 +20,6 @@ LDB_KEY_PREFIX_FORMAT = '>BI'
 LDB_KEY_PREFIX_LENGTH = struct.calcsize(LDB_KEY_PREFIX_FORMAT)
 LDB_ZSET_SCORE_FORMAT = '>d'
 
-# ldb sorts elements lexicographically and negative numbers
-# when converted to binary are "bigger" than positives.
-# zero is the lowest byte combination.
-LDB_MIN_ZSET_SCORE = 0
-
 
 class LDBKeyCodec(object):
 

--- a/dredis/ldb.py
+++ b/dredis/ldb.py
@@ -1,0 +1,75 @@
+import struct
+
+import plyvel
+
+LDB_DBS = {}
+LDB_STRING_TYPE = 1
+LDB_SET_TYPE = 2
+LDB_SET_MEMBER_TYPE = 3
+LDB_HASH_TYPE = 4
+LDB_HASH_FIELD_TYPE = 5
+LDB_ZSET_TYPE = 6
+LDB_ZSET_VALUE_TYPE = 7
+LDB_ZSET_SCORE_TYPE = 8
+LDB_KEY_TYPES = [LDB_STRING_TYPE, LDB_SET_TYPE, LDB_HASH_TYPE, LDB_ZSET_TYPE]
+
+# type_id | key_length
+LDB_KEY_PREFIX_FORMAT = '>BI'
+LDB_KEY_PREFIX_LENGTH = struct.calcsize(LDB_KEY_PREFIX_FORMAT)
+LDB_ZSET_SCORE_FORMAT = '>d'
+
+# ldb sorts elements lexicographically and negative numbers
+# when converted to binary are "bigger" than positives.
+# zero is the lowest byte combination.
+LDB_MIN_ZSET_SCORE = 0
+
+
+class LDBKeyCodec(object):
+
+    def get_key(self, key, type_id):
+        prefix = struct.pack(LDB_KEY_PREFIX_FORMAT, type_id, len(key))
+        return prefix + bytes(key)
+
+    def encode_string(self, key):
+        return self.get_key(key, LDB_STRING_TYPE)
+
+    def encode_set(self, key):
+        return self.get_key(key, LDB_SET_TYPE)
+
+    def encode_set_member(self, key, value):
+        return self.get_key(key, LDB_SET_MEMBER_TYPE) + bytes(value)
+
+    def encode_hash(self, key):
+        return self.get_key(key, LDB_HASH_TYPE)
+
+    def encode_hash_field(self, key, field):
+        return self.get_key(key, LDB_HASH_FIELD_TYPE) + bytes(field)
+
+    def encode_zset(self, key):
+        return self.get_key(key, LDB_ZSET_TYPE)
+
+    def encode_zset_value(self, key, value):
+        return self.get_key(key, LDB_ZSET_VALUE_TYPE) + bytes(value)
+
+    def encode_zset_score(self, key, value, score):
+        return self.get_key(key, LDB_ZSET_SCORE_TYPE) + struct.pack(LDB_ZSET_SCORE_FORMAT, float(score)) + bytes(value)
+
+    def decode_key(self, key):
+        type_id, key_length = struct.unpack(LDB_KEY_PREFIX_FORMAT, key[:LDB_KEY_PREFIX_LENGTH])
+        key_value = key[LDB_KEY_PREFIX_LENGTH:]
+        return type_id, key_length, key_value
+
+    def decode_zset_score(self, ldb_key):
+        _, length, key_name = self.decode_key(ldb_key)
+        return struct.unpack(LDB_ZSET_SCORE_FORMAT, key_name[length:length + struct.calcsize(LDB_ZSET_SCORE_FORMAT)])[0]
+
+    def decode_zset_value(self, ldb_key):
+        _, length, key_name = self.decode_key(ldb_key)
+        return key_name[length + struct.calcsize(LDB_ZSET_SCORE_FORMAT):]
+
+
+KEY_CODEC = LDBKeyCodec()
+
+
+def get_ldb(path):
+    return plyvel.DB(bytes(path), create_if_missing=True)

--- a/dredis/ldb.py
+++ b/dredis/ldb.py
@@ -74,5 +74,5 @@ class LDBKeyCodec(object):
 KEY_CODEC = LDBKeyCodec()
 
 
-def get_ldb(path):
+def open_ldb(path):
     return plyvel.DB(bytes(path), create_if_missing=True)

--- a/dredis/ldb.py
+++ b/dredis/ldb.py
@@ -41,11 +41,17 @@ class LDBKeyCodec(object):
     def encode_set_member(self, key, value):
         return self.get_key(key, LDB_SET_MEMBER_TYPE) + bytes(value)
 
+    def get_min_set_member(self, key):
+        return self.get_key(key, LDB_SET_MEMBER_TYPE)
+
     def encode_hash(self, key):
         return self.get_key(key, LDB_HASH_TYPE)
 
     def encode_hash_field(self, key, field):
         return self.get_key(key, LDB_HASH_FIELD_TYPE) + bytes(field)
+
+    def get_min_hash_field(self, key):
+        return self.get_key(key, LDB_HASH_FIELD_TYPE)
 
     def encode_zset(self, key):
         return self.get_key(key, LDB_ZSET_TYPE)
@@ -70,7 +76,10 @@ class LDBKeyCodec(object):
         return key_name[length + struct.calcsize(LDB_ZSET_SCORE_FORMAT):]
 
     def get_min_zset_score(self, key):
-        return self.encode_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
+        return self.get_key(key, LDB_ZSET_SCORE_TYPE)
+
+    def get_min_zset_value(self, key):
+        return self.get_key(key, LDB_ZSET_VALUE_TYPE)
 
 
 class LevelDB(object):
@@ -102,6 +111,7 @@ class LevelDB(object):
             'db': self.open_db(directory),
             'directory': directory,
         }
+
 
 KEY_CODEC = LDBKeyCodec()
 LEVELDB = LevelDB()

--- a/dredis/ldb.py
+++ b/dredis/ldb.py
@@ -67,6 +67,9 @@ class LDBKeyCodec(object):
         _, length, key_name = self.decode_key(ldb_key)
         return key_name[length + struct.calcsize(LDB_ZSET_SCORE_FORMAT):]
 
+    def get_min_zset_score(self, key):
+        return self.encode_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
+
 
 KEY_CODEC = LDBKeyCodec()
 

--- a/dredis/ldb.py
+++ b/dredis/ldb.py
@@ -28,6 +28,12 @@ LDB_MIN_ZSET_SCORE = 0
 
 class LDBKeyCodec(object):
 
+    # the key format using <key length + key> was inspired by the `blackwidow` project:
+    # https://github.com/KernelMaker/blackwidow/blob/5abe9a3e3f035dd0d81f514e598f29c1db679a28/src/zsets_data_key_format.h#L44-L53
+    # https://github.com/KernelMaker/blackwidow/blob/5abe9a3e3f035dd0d81f514e598f29c1db679a28/src/base_data_key_format.h#L37-L43
+    #
+    # LevelDB doesn't have column families like RocksDB, so the binary prefixes were created to distinguish object types
+
     def get_key(self, key, type_id):
         prefix = struct.pack(LDB_KEY_PREFIX_FORMAT, type_id, len(key))
         return prefix + bytes(key)

--- a/dredis/ldb.py
+++ b/dredis/ldb.py
@@ -79,13 +79,13 @@ class LevelDB(object):
         for db_id_ in range(16):
             db_id = str(db_id_)
             directory = Path(root_dir).join(db_id)
-            LDB_DBS[db_id] = (self.open_db(directory), directory)
+            self._assign_db(db_id, directory)
 
     def open_db(self, path):
         return plyvel.DB(bytes(path), create_if_missing=True)
 
     def get_db(self, db_id):
-        return LDB_DBS[str(db_id)][0]
+        return LDB_DBS[str(db_id)]['db']
 
     def delete_dbs(self):
         for db_id in LDB_DBS:
@@ -93,11 +93,15 @@ class LevelDB(object):
 
     def delete_db(self, db_id):
         db_id = str(db_id)
-        db, directory = LDB_DBS[db_id]
-        db.close()
-        directory.reset()
-        LDB_DBS[db_id] = (self.open_db(directory), directory)
+        LDB_DBS[db_id]['db'].close()
+        LDB_DBS[db_id]['directory'].reset()
+        self._assign_db(db_id, LDB_DBS[db_id]['directory'])
 
+    def _assign_db(self, db_id, directory):
+        LDB_DBS[db_id] = {
+            'db': self.open_db(directory),
+            'directory': directory,
+        }
 
 KEY_CODEC = LDBKeyCodec()
 LEVELDB = LevelDB()

--- a/dredis/ldb.py
+++ b/dredis/ldb.py
@@ -73,27 +73,32 @@ class LDBKeyCodec(object):
         return self.encode_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
 
 
+
+class LevelDB(object):
+
+    def setup_dbs(self, root_dir):
+        for db_id_ in range(16):
+            db_id = str(db_id_)
+            directory = Path(root_dir).join(db_id)
+            LDB_DBS[db_id] = (self.open_db(directory), directory)
+
+    def open_db(self, path):
+        return plyvel.DB(bytes(path), create_if_missing=True)
+
+    def get_db(self, db_id):
+        return LDB_DBS[str(db_id)][0]
+
+    def delete_dbs(self):
+        for db_id in LDB_DBS:
+            self.delete_db(db_id)
+
+    def delete_db(self, db_id):
+        db_id = str(db_id)
+        db, directory = LDB_DBS[db_id]
+        db.close()
+        directory.reset()
+        LDB_DBS[db_id] = (self.open_db(directory), directory)
+
+
 KEY_CODEC = LDBKeyCodec()
-
-
-def setup_ldb(root_dir):
-    for db_id_ in range(16):
-        db_id = str(db_id_)
-        directory = Path(root_dir).join(db_id)
-        LDB_DBS[db_id] = (open_ldb(directory), directory)
-
-
-def open_ldb(path):
-    return plyvel.DB(bytes(path), create_if_missing=True)
-
-
-def get_ldb(db_id):
-    return LDB_DBS[str(db_id)][0]
-
-
-def flush_ldb(db_id_):
-    db_id = str(db_id_)
-    db, directory = LDB_DBS[db_id]
-    db.close()
-    directory.reset()
-    LDB_DBS[db_id] = (open_ldb(directory), directory)
+LEVELDB = LevelDB()

--- a/dredis/ldb.py
+++ b/dredis/ldb.py
@@ -2,6 +2,8 @@ import struct
 
 import plyvel
 
+from dredis.path import Path
+
 LDB_DBS = {}
 LDB_STRING_TYPE = 1
 LDB_SET_TYPE = 2
@@ -74,5 +76,24 @@ class LDBKeyCodec(object):
 KEY_CODEC = LDBKeyCodec()
 
 
+def setup_ldb(root_dir):
+    for db_id_ in range(16):
+        db_id = str(db_id_)
+        directory = Path(root_dir).join(db_id)
+        LDB_DBS[db_id] = (open_ldb(directory), directory)
+
+
 def open_ldb(path):
     return plyvel.DB(bytes(path), create_if_missing=True)
+
+
+def get_ldb(db_id):
+    return LDB_DBS[str(db_id)][0]
+
+
+def flush_ldb(db_id_):
+    db_id = str(db_id_)
+    db, directory = LDB_DBS[db_id]
+    db.close()
+    directory.reset()
+    LDB_DBS[db_id] = (open_ldb(directory), directory)

--- a/dredis/ldb.py
+++ b/dredis/ldb.py
@@ -73,7 +73,6 @@ class LDBKeyCodec(object):
         return self.encode_zset_score(key, bytes(''), LDB_MIN_ZSET_SCORE)
 
 
-
 class LevelDB(object):
 
     def setup_dbs(self, root_dir):

--- a/dredis/path.py
+++ b/dredis/path.py
@@ -1,13 +1,9 @@
 import errno
-import fnmatch
 import os.path
 import shutil
-import struct
 
 import six
 import sys
-
-from scandir import scandir
 
 
 class Path(str):
@@ -19,40 +15,6 @@ class Path(str):
         shutil.rmtree(self, ignore_errors=True)
         os.makedirs(self)
 
-    def read(self):
-        with open(self, 'rb') as f:
-            result = f.read()
-        return result
-
-    def write(self, content):
-        with open(self, 'wb') as f:
-            f.write(content)
-
-    def delete(self):
-        if os.path.isfile(self):
-            os.remove(self)
-        else:
-            shutil.rmtree(self)
-
-    def append(self, line):
-        try:
-            encoder = ZSetEncoder(open(self, 'rb+'))
-        except IOError:
-            encoder = ZSetEncoder(open(self, 'wb'))
-            old_size = 0
-        else:
-            old_size = encoder.read_header()
-
-        encoder.write_header(old_size + 1)
-        encoder.write_element_to_eof(line)
-
-    def readlines(self):
-        with open(self, 'rb') as f:
-            return ZSetEncoder(f).read_elements()
-
-    def exists(self):
-        return os.path.exists(self)
-
     def makedirs(self, ignore_if_exists=False):
         try:
             return os.makedirs(self)
@@ -61,82 +23,3 @@ class Path(str):
                 pass
             else:
                 six.reraise(*sys.exc_info())
-
-    def listdir(self, pattern=None):
-        all_files = os.listdir(self)
-        if pattern is None:
-            return all_files
-        else:
-            return list(fnmatch.filter(all_files, pattern))
-
-    def remove_line(self, line_to_remove):
-        lines = self.readlines()
-        if line_to_remove in lines:
-            lines.remove(line_to_remove)
-            if len(lines) == 0:
-                os.remove(self)
-            else:
-                with open(self, 'wb') as f:
-                    ZSetEncoder(f).rewrite_content(lines)
-
-    def empty_directory(self):
-        if self.exists():
-            try:
-                next(scandir(self))
-            except StopIteration:
-                return True
-            else:
-                return False
-        else:
-            return False
-
-    def read_zset_header(self):
-        with open(self, 'rb') as f:
-            return ZSetEncoder(f).read_header()
-
-
-class ZSetEncoder(object):
-
-    HEADER_FMT = ">Q"
-    HEADER_BYTES = 8
-    ELEMENT_FMT = ">I"
-    SIZE_BYTES = 4
-
-    def __init__(self, file_):
-        self._file = file_
-
-    def write_header(self, size, seek_to_start=True):
-        if seek_to_start:
-            self._file.seek(0, os.SEEK_SET)
-        self._file.write(struct.pack(self.HEADER_FMT, size))
-
-    def read_header(self):
-        return struct.unpack(self.HEADER_FMT, self._file.read(self.HEADER_BYTES))[0]
-
-    def write_element(self, element):
-        self._file.write(struct.pack(self.ELEMENT_FMT, len(element)))
-        self._file.write(element)
-
-    def write_element_to_eof(self, element):
-        self.move_to_eof()
-        self.write_element(element)
-
-    def read_element(self):
-        size_string = self._file.read(self.SIZE_BYTES)
-        size = struct.unpack(self.ELEMENT_FMT, size_string)[0]
-        return self._file.read(size)
-
-    def rewrite_content(self, lines):
-        self.write_header(len(lines), seek_to_start=False)
-        for line in lines:
-            self.write_element(line)
-
-    def read_elements(self):
-        count = self.read_header()
-        return [self.read_element() for _ in xrange(count)]
-
-    def skip_header(self):
-        self._file.seek(self.HEADER_BYTES, os.SEEK_SET)
-
-    def move_to_eof(self):
-        self._file.seek(0, os.SEEK_END)

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -148,8 +148,6 @@ def main():
     keyspace = DiskKeyspace(ROOT_DIR)
     if args.flushall:
         keyspace.flushall()
-    else:
-        keyspace.setup_directories()
 
     RedisServer(args.host, args.port)
 

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -12,7 +12,7 @@ import sys
 from dredis import __version__
 from dredis.commands import run_command, SimpleString, CommandNotFound
 from dredis.keyspace import Keyspace
-from dredis.ldb import setup_ldb
+from dredis.ldb import LEVELDB
 from dredis.lua import RedisScriptError
 from dredis.parser import Parser
 from dredis.path import Path
@@ -146,7 +146,7 @@ def main():
     else:
         setup_logging(logging.INFO)
 
-    setup_ldb(ROOT_DIR)
+    LEVELDB.setup_dbs(ROOT_DIR)
     keyspace = Keyspace()
     if args.flushall:
         keyspace.flushall()

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -11,7 +11,7 @@ import sys
 
 from dredis import __version__
 from dredis.commands import run_command, SimpleString, CommandNotFound
-from dredis.keyspace import DiskKeyspace
+from dredis.keyspace import Keyspace
 from dredis.lua import RedisScriptError
 from dredis.parser import Parser
 from dredis.path import Path
@@ -93,7 +93,7 @@ class CommandHandler(asyncore.dispatcher):
     @property
     def keyspace(self):
         if self.addr not in KEYSPACES:
-            KEYSPACES[self.addr] = DiskKeyspace(ROOT_DIR)
+            KEYSPACES[self.addr] = Keyspace(ROOT_DIR)
         return KEYSPACES[self.addr]
 
 
@@ -145,7 +145,7 @@ def main():
     else:
         setup_logging(logging.INFO)
 
-    keyspace = DiskKeyspace(ROOT_DIR)
+    keyspace = Keyspace(ROOT_DIR)
     if args.flushall:
         keyspace.flushall()
 

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -12,6 +12,7 @@ import sys
 from dredis import __version__
 from dredis.commands import run_command, SimpleString, CommandNotFound
 from dredis.keyspace import Keyspace
+from dredis.ldb import setup_ldb
 from dredis.lua import RedisScriptError
 from dredis.parser import Parser
 from dredis.path import Path
@@ -93,7 +94,7 @@ class CommandHandler(asyncore.dispatcher):
     @property
     def keyspace(self):
         if self.addr not in KEYSPACES:
-            KEYSPACES[self.addr] = Keyspace(ROOT_DIR)
+            KEYSPACES[self.addr] = Keyspace()
         return KEYSPACES[self.addr]
 
 
@@ -145,7 +146,8 @@ def main():
     else:
         setup_logging(logging.INFO)
 
-    keyspace = Keyspace(ROOT_DIR)
+    setup_ldb(ROOT_DIR)
+    keyspace = Keyspace()
     if args.flushall:
         keyspace.flushall()
 

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -14,7 +14,7 @@ from dredis.commands import run_command, SimpleString, CommandNotFound
 from dredis.keyspace import DiskKeyspace
 from dredis.lua import RedisScriptError
 from dredis.parser import Parser
-
+from dredis.path import Path
 
 logger = logging.getLogger('dredis')
 
@@ -134,7 +134,9 @@ def main():
 
     global ROOT_DIR
     if args.dir:
-        ROOT_DIR = args.dir
+        ROOT_DIR = Path(args.dir)
+        ROOT_DIR.makedirs(ignore_if_exists=True)
+
     else:
         ROOT_DIR = tempfile.mkdtemp(prefix="redis-test-")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 lupa
 six
-scandir
 plyvel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 lupa
 six
 scandir
+plyvel

--- a/tests-performance/test_zset_performance.py
+++ b/tests-performance/test_zset_performance.py
@@ -2,16 +2,16 @@
 The following results should serve as reference
 ------
 
-Results from 2018-11-12 on @htlbra's Macbook (LARGE_NUMBER == 1000):
+Results from 2019-01-18 on @htlbra's Macbook (LARGE_NUMBER == 1000):
 
 $ make performance-server & make test-performance | grep 'zset Z'
-zset ZADD time = 0.46967s
-zset ZADD time = 0.69122s
-zset ZCARD time = 0.00120s
-zset ZRANK time = 0.00196s
-zset ZCOUNT time = 0.00030s
-zset ZRANGE time = 0.02062s
-zset ZREM time = 2.52095s
+zset ZADD time = 0.17577s
+zset ZADD time = 0.18646s
+zset ZCARD time = 0.00012s
+zset ZRANK time = 0.00338s
+zset ZCOUNT time = 0.00530s
+zset ZRANGE time = 0.00834s
+zset ZREM time = 0.16809s
 
 
 $ redis-server --port 6376 & make test-performance | grep time

--- a/tests-performance/test_zset_performance.py
+++ b/tests-performance/test_zset_performance.py
@@ -2,16 +2,16 @@
 The following results should serve as reference
 ------
 
-Results from 2019-01-18 on @htlbra's Macbook (LARGE_NUMBER == 1000):
+Results from 2019-01-23 on @htlbra's Macbook (LARGE_NUMBER == 1000):
 
 $ make performance-server & make test-performance | grep 'zset Z'
-zset ZADD time = 0.17577s
-zset ZADD time = 0.18646s
-zset ZCARD time = 0.00012s
-zset ZRANK time = 0.00338s
-zset ZCOUNT time = 0.00530s
-zset ZRANGE time = 0.00834s
-zset ZREM time = 0.16809s
+zset ZADD time = 0.16834s
+zset ZADD time = 0.16564s
+zset ZCARD time = 0.00011s
+zset ZRANK time = 0.00379s
+zset ZCOUNT time = 0.00536s
+zset ZRANGE time = 0.00872s
+zset ZREM time = 0.14646s
 
 
 $ redis-server --port 6376 & make test-performance | grep time

--- a/tests/integration/test_hash.py
+++ b/tests/integration/test_hash.py
@@ -107,4 +107,4 @@ def test_hset_should_accept_multiple_key_value_pairs():
 
     with pytest.raises(redis.ResponseError) as exc:
         r.execute_command('HSET', 'myhash', 'k1', 'v1', 'k2')
-    assert exc.value.message == 'wrong number of arguments for HMSET'
+    assert str(exc.value) == 'wrong number of arguments for HMSET'

--- a/tests/integration/test_keys.py
+++ b/tests/integration/test_keys.py
@@ -57,3 +57,15 @@ def test_exists():
 
     # redis-py doesn't support multiple args to `r.exists()`
     assert r.execute_command('EXISTS', 'mystr', 'notfound') == 1
+
+
+def test_delete():
+    r = fresh_redis()
+
+    r.set('mystr', 'test')
+    r.sadd('myset', 'elem1')
+    r.zadd('myzset', 0, 'elem1')
+    r.hset('myhash', 'testkey', 'testvalue')
+
+    assert r.delete('mystr', 'myset', 'myzset', 'myhash', 'notfound') == 4
+    assert r.keys('*') == []

--- a/tests/integration/test_keys.py
+++ b/tests/integration/test_keys.py
@@ -41,9 +41,19 @@ def test_keys():
 def test_exists():
     r = fresh_redis()
 
+    assert r.exists('notfound') == 0
+
     r.set('mystr', 'test')
     assert r.exists('mystr') == 1
-    assert r.exists('notfound') == 0
+
+    r.sadd('myset', 'elem1')
+    assert r.exists('myset') == 1
+
+    r.zadd('myzset', 0, 'elem1')
+    assert r.exists('myzset') == 1
+
+    r.hset('myhash', 'testkey', 'testvalue')
+    assert r.exists('myhash') == 1
 
     # redis-py doesn't support multiple args to `r.exists()`
     assert r.execute_command('EXISTS', 'mystr', 'notfound') == 1

--- a/tests/integration/test_keys.py
+++ b/tests/integration/test_keys.py
@@ -27,13 +27,14 @@ def test_keys():
     r.incr('myint')
     r.sadd('myset', 'test')
     r.zadd('myzset', 0, 'test')
+    r.hset('myhash', 'test', 'testvalue')
 
     assert r.keys('myi*') == ['myint']
 
     # order isn't guaranteed
     all_keys = r.keys('*')
-    assert len(all_keys) == 4
-    assert sorted(all_keys) == sorted(['mystr', 'myint', 'myset', 'myzset'])
+    assert len(all_keys) == 5
+    assert sorted(all_keys) == sorted(['mystr', 'myint', 'myset', 'myzset', 'myhash'])
     assert sorted(r.keys('my*set')) == sorted(['myset', 'myzset'])
     assert r.keys('my?et') == ['myset']
 

--- a/tests/integration/test_leveldb.py
+++ b/tests/integration/test_leveldb.py
@@ -1,0 +1,20 @@
+import tempfile
+
+from dredis.keyspace import Keyspace
+from dredis.ldb import LEVELDB
+
+
+def test_delete():
+    tempdir = tempfile.mkdtemp(prefix="redis-test-")
+    LEVELDB.setup_dbs(tempdir)
+    keyspace = Keyspace()
+
+    keyspace.select('0')
+    keyspace.set('mystr', 'test')
+    keyspace.sadd('myset', 'elem1')
+    keyspace.zadd('myzset', 0, 'elem1')
+    keyspace.hset('myhash', 'testkey', 'testvalue')
+
+    keyspace.delete('mystr', 'myset', 'myzset', 'myhash', 'notfound')
+
+    assert list(LEVELDB.get_db('0').iterator()) == []

--- a/tests/integration/test_scripting.py
+++ b/tests/integration/test_scripting.py
@@ -23,14 +23,14 @@ def test_lua_with_redis_error_call():
     r = fresh_redis()
     with pytest.raises(redis.ResponseError) as exc:
         r.eval("""return redis.call('cmd_not_found')""", 0)
-    assert exc.value.message.strip().endswith('Unknown Redis command called from Lua script')
+    assert str(exc.value).strip().endswith('Unknown Redis command called from Lua script')
 
 
 def test_lua_with_redis_error_pcall():
     r = fresh_redis()
     with pytest.raises(redis.ResponseError) as exc:
         r.eval("""return redis.pcall('cmd_not_found')""", 0)
-    assert exc.value.message.strip().endswith('Unknown Redis command called from Lua script')
+    assert str(exc.value).strip().endswith('Unknown Redis command called from Lua script')
 
 
 def test_commands_should_be_case_insensitive_inside_lua():

--- a/tests/integration/test_sets.py
+++ b/tests/integration/test_sets.py
@@ -32,3 +32,4 @@ def test_scard():
     r.sadd('myset', 'myvalue2')
 
     assert r.scard('myset') == 2
+    assert r.scard('notfound') == 0

--- a/tests/integration/test_strings.py
+++ b/tests/integration/test_strings.py
@@ -81,4 +81,4 @@ def test_get_arity():
 
     with pytest.raises(redis.ResponseError) as exc:
         r.execute_command('GET')
-    assert exc.value.message == "wrong number of arguments for 'get' command"
+    assert str(exc.value) == "wrong number of arguments for 'get' command"

--- a/tests/integration/test_zset.py
+++ b/tests/integration/test_zset.py
@@ -112,10 +112,18 @@ def test_zscore():
 
     r.zadd('myzset', 0, 'myvalue1')
     r.zadd('myzset', 1, 'myvalue2')
+    r.zadd('myzset', 2.0, 'decimal1')
+    r.zadd('myzset', 2.3, 'decimal2')
 
     assert r.zscore('myzset', 'myvalue1') == 0
     assert r.zscore('myzset', 'myvalue2') == 1
+    assert r.zscore('myzset', 'decimal1') == 2.0
+    assert r.zscore('myzset', 'decimal2') == 2.3
+
     assert r.zscore('myzset', 'notfound') is None
+    # the `redis-py` library converts `zscore` results to float automatically,
+    # and the following tests want to confirm the raw response from Redis
+    assert r.eval("return redis.call('zscore', 'myzset', 'decimal1')", 0) == '2'
 
 
 def test_zrangebyscore():

--- a/tests/integration/test_zset.py
+++ b/tests/integration/test_zset.py
@@ -263,7 +263,7 @@ def test_zadd_should_only_accept_pairs():
 
     with pytest.raises(redis.ResponseError) as exc:
         r.execute_command('ZADD', 'mykey', 0, 'myvalue1', 1)
-    assert exc.value.message == "syntax error"
+    assert str(exc.value) == "syntax error"
 
 
 def test_zrange_should_only_accept_withscores_as_extra_argument():
@@ -271,7 +271,7 @@ def test_zrange_should_only_accept_withscores_as_extra_argument():
 
     with pytest.raises(redis.ResponseError) as exc:
         r.execute_command('ZRANGE', 'mykey', 0, 1, 'bleh')
-    assert exc.value.message == "syntax error"
+    assert str(exc.value) == "syntax error"
     assert r.execute_command('ZRANGE', 'mykey', 0, 1, 'WITHSCORES') == []
 
 
@@ -280,11 +280,11 @@ def test_zrangebyscore_should_validate_withscores_and_limit_extra_arguments():
 
     with pytest.raises(redis.ResponseError) as exc1:
         r.execute_command('ZRANGEBYSCORE', 'mykey', 0, 1, 'bleh', 'WITHSCORES', 'LIMIT', 0)  # missing count
-    assert exc1.value.message == "syntax error"
+    assert str(exc1.value) == "syntax error"
 
     with pytest.raises(redis.ResponseError) as exc2:
         r.execute_command('ZRANGEBYSCORE', 'mykey', 0, 1, 'bleh', 'extraword')  # unknown parameter
-    assert exc2.value.message == "syntax error"
+    assert str(exc2.value) == "syntax error"
 
 
 def test_zrangebyscore_should_validate_limit_values_as_integers():
@@ -292,11 +292,11 @@ def test_zrangebyscore_should_validate_limit_values_as_integers():
 
     with pytest.raises(redis.ResponseError) as exc1:
         r.execute_command('ZRANGEBYSCORE', 'mykey', 0, 1, 'bleh',  'LIMIT', 0, 's')
-    assert exc1.value.message == "syntax error"
+    assert str(exc1.value) == "syntax error"
 
     with pytest.raises(redis.ResponseError) as exc2:
         r.execute_command('ZRANGEBYSCORE', 'mykey', 0, 1, 'bleh',  'LIMIT', 's', 1)
-    assert exc2.value.message == "syntax error"
+    assert str(exc2.value) == "syntax error"
 
 
 def test_zrangebyscore_with_limit_from_official_redis_tests():
@@ -318,19 +318,19 @@ def test_invalid_floats():
 
     with pytest.raises(redis.ResponseError) as exc1:
         r.zrangebyscore('myzset', 'invalid', 0)
-    assert exc1.value.message == 'min or max is not a float'
+    assert str(exc1.value) == 'min or max is not a float'
 
     with pytest.raises(redis.ResponseError) as exc2:
         r.zrangebyscore('myzset', 0, 'invalid')
-    assert exc2.value.message == 'min or max is not a float'
+    assert str(exc2.value) == 'min or max is not a float'
 
     with pytest.raises(redis.ResponseError) as exc3:
         r.zrangebyscore('myzset', 0, 'NaN')
-    assert exc3.value.message == 'min or max is not a float'
+    assert str(exc3.value) == 'min or max is not a float'
 
     with pytest.raises(redis.ResponseError) as exc4:
         r.zrangebyscore('myzset', 'NaN', 0)
-    assert exc4.value.message == 'min or max is not a float'
+    assert str(exc4.value) == 'min or max is not a float'
 
 
 def test_zadd_with_newlines():

--- a/tests/integration/test_zset.py
+++ b/tests/integration/test_zset.py
@@ -340,3 +340,15 @@ def test_zadd_with_newlines():
 
     assert r.zcard('myzset') == 2
     assert r.zrange('myzset', 0, 1) == ['my\nsecond\nstring', 'my\ntest\nstring']
+
+
+def test_deleting_a_zset_should_not_impact_other_zsets():
+    # this is a regression test
+    r = fresh_redis()
+    r.zadd('myzset1', 0, 'test1')
+    r.zadd('myzset2', 0, 'test2')
+
+    r.delete('myzset1')
+
+    assert r.keys('*') == ['myzset2']
+    assert r.zrange('myzset2', 0, 10) == ['test2']

--- a/tests/integration/test_zset.py
+++ b/tests/integration/test_zset.py
@@ -104,6 +104,7 @@ def test_zrem():
     assert r.zrem('myzset', 'notfound') == 0
 
     assert r.zrange('myzset', 0, -1) == ['myvalue0', 'myvalue3', 'myvalue2']
+    assert r.zcard('myzset') == 3
 
 
 def test_zscore():

--- a/tests/unit/test_eval.py
+++ b/tests/unit/test_eval.py
@@ -13,7 +13,7 @@ def test_eval_with_error_call():
 
     with pytest.raises(RedisScriptError) as exc:
         k.eval("""return redis.call('cmd_not_found')""", [], [])
-    assert exc.value.message == '@user_script: Unknown Redis command called from Lua script'
+    assert str(exc.value) == '@user_script: Unknown Redis command called from Lua script'
 
 
 def test_eval_with_error_pcall():

--- a/tests/unit/test_eval.py
+++ b/tests/unit/test_eval.py
@@ -2,14 +2,14 @@ import tempfile
 
 import pytest
 
-from dredis.keyspace import DiskKeyspace
+from dredis.keyspace import Keyspace
 from dredis.lua import RedisScriptError
 
 test_dir = tempfile.mkdtemp(prefix="redis-test-")
 
 
 def test_eval_with_error_call():
-    k = DiskKeyspace(test_dir)
+    k = Keyspace(test_dir)
 
     with pytest.raises(RedisScriptError) as exc:
         k.eval("""return redis.call('cmd_not_found')""", [], [])
@@ -17,7 +17,7 @@ def test_eval_with_error_call():
 
 
 def test_eval_with_error_pcall():
-    k = DiskKeyspace(test_dir)
+    k = Keyspace(test_dir)
 
     with pytest.raises(ValueError, message='ERR Error running script: @user_script: Unknown Redis command called from Lua script'):
         k.eval("""return redis.pcall('cmd_not_found')""", [], [])

--- a/tests/unit/test_eval.py
+++ b/tests/unit/test_eval.py
@@ -9,7 +9,7 @@ test_dir = tempfile.mkdtemp(prefix="redis-test-")
 
 
 def test_eval_with_error_call():
-    k = Keyspace(test_dir)
+    k = Keyspace()
 
     with pytest.raises(RedisScriptError) as exc:
         k.eval("""return redis.call('cmd_not_found')""", [], [])
@@ -17,7 +17,7 @@ def test_eval_with_error_call():
 
 
 def test_eval_with_error_pcall():
-    k = Keyspace(test_dir)
+    k = Keyspace()
 
     with pytest.raises(ValueError, message='ERR Error running script: @user_script: Unknown Redis command called from Lua script'):
         k.eval("""return redis.pcall('cmd_not_found')""", [], [])


### PR DESCRIPTION
I migrated all of the storage to use LevelDB. The results are significantly better and I am ready to try this on a couple of production systems.

I have tried different backends before and they didn't perform better than what we had. I picked LevelDB because it's a small library and a lot simpler than RockDB (fewer features, fewer options, smaller in size). I am definitely considering RocksDB if we think the performance can be better with the usage of column families instead of one keyspace with every value in it.

---

With this pull request, there's one LevelDB database per Redis database (16 total).
Each data structure has at least one key on LevelDB:

type | number of keys in leveldb
-----|--------------------------
string | 1
hash | 1 + 1 key per field
set | 1 + 1 key per element
sorted set | 1 + 1 per score + 1 per element


type | data it stores
-----|-------------
string | key value
hash | number of elements in the hash
hash field | value of the hash field
set | number of elements in the set
set element | nothing
sorted set | number of elements in the sorted set
sorted set element | the score of the element
sorted set score | nothing



All LevelDB keys have prefixes indicating their type (e.g., hash field, set member, sorted set score). The prefixes were inspired by the [blackwidow](https://github.com/KernelMaker/blackwidow) project <a href="https://github.com/KernelMaker/blackwidow/blob/5abe9a3e3f035dd0d81f514e598f29c1db679a28/src/zsets_data_key_format.h#L44-L53"><sup>1</sup></a> <a href="https://github.com/KernelMaker/blackwidow/blob/5abe9a3e3f035dd0d81f514e598f29c1db679a28/src/base_data_key_format.h#L37-L43"><sup>2</sup></a>


Examples:

```python
>>> from dredis.ldb import LEVELDB
>>> from dredis.keyspace import Keyspace
>>> LEVELDB.setup_dbs('/tmp/tests')
>>> keyspace = Keyspace()
>>> keyspace.set('mystring', 'stringvalue')
>>> keyspace.hset('myhash', 'field1', 'value1')
1
>>> keyspace.sadd('myset', 'member1')
1
>>> keyspace.zadd('mysortedset', 5, 'element1')
1
>>> keyspace.zadd('mysortedset', 10, 'element2')
1
>>> for db_key, db_value in LEVELDB.get_db('0'):
...     print('%r = %r' % (db_key, db_value))
... 
'\x01\x00\x00\x00\x08mystring' = 'stringvalue'
'\x02\x00\x00\x00\x05myset' = '1'
'\x03\x00\x00\x00\x05mysetmember1' = ''
'\x04\x00\x00\x00\x06myhash' = '1'
'\x05\x00\x00\x00\x06myhashfield1' = 'value1'
'\x06\x00\x00\x00\x0bmysortedset' = '2'
'\x07\x00\x00\x00\x0bmysortedsetelement1' = '5'
'\x07\x00\x00\x00\x0bmysortedsetelement2' = '10'
'\x08\x00\x00\x00\x0bmysortedset@\x14\x00\x00\x00\x00\x00\x00element1' = ''
'\x08\x00\x00\x00\x0bmysortedset@$\x00\x00\x00\x00\x00\x00element2' = ''

```