### PR TITLE
Improve TCP communication

### DIFF
--- a/dredis/server.py
+++ b/dredis/server.py
@@ -75,9 +75,12 @@ def transmit(send_fn, result):
 
 class CommandHandler(asyncore.dispatcher):
 
+    def __init__(self, *args, **kwargs):
+        asyncore.dispatcher.__init__(self, *args, **kwargs)
+        self._parser = Parser(self.recv)  # contains client message buffer
+
     def handle_read(self):
-        parser = Parser(self.recv)
-        for cmd in parser.get_instructions():
+        for cmd in self._parser.get_instructions():
             logger.debug('{} data = {}'.format(self.addr, repr(cmd)))
             execute_cmd(self.keyspace, self.debug_send, *cmd)
 

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncore
+import errno
 import json
 import logging
 import os.path
@@ -80,9 +81,16 @@ class CommandHandler(asyncore.dispatcher):
         self._parser = Parser(self.recv)  # contains client message buffer
 
     def handle_read(self):
-        for cmd in self._parser.get_instructions():
-            logger.debug('{} data = {}'.format(self.addr, repr(cmd)))
-            execute_cmd(self.keyspace, self.debug_send, *cmd)
+        try:
+            for cmd in self._parser.get_instructions():
+                logger.debug('{} data = {}'.format(self.addr, repr(cmd)))
+                execute_cmd(self.keyspace, self.debug_send, *cmd)
+        except socket.error as exc:
+            # try again later if no data is available
+            if exc.errno == errno.EAGAIN:
+                return
+            else:
+                raise
 
     def debug_send(self, *args):
         logger.debug("out={}".format(repr(args)))


### PR DESCRIPTION
I saw some issues when I was running stress tests against an EC2 server and realized that I did a terrible job with the TCP communication in the previous releases.

The proper way (copied from Redis) is to ignore half-baked messages and buffer them instead of expecting the communication to have everything ready to go.

The changes in `server.py` aren't covered by tests because I couldn't replicate this issue locally, even with https://github.com/sitespeedio/throttle.