### PR TITLE
Refactor and Test server.py

### DIFF
--- a/development.txt
+++ b/development.txt
@@ -2,4 +2,5 @@
 pytest
 redis==2.10.6
 flake8
+mock
 twine

--- a/dredis/commands.py
+++ b/dredis/commands.py
@@ -377,6 +377,6 @@ def run_command(keyspace, cmd, args):
 
     str_args = map(str, args)
     if cmd.upper() not in REDIS_COMMANDS:
-        raise CommandNotFound()
+        raise CommandNotFound("unknown command '{}'".format(cmd))
     else:
         return REDIS_COMMANDS[cmd.upper()](keyspace, *str_args)

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -51,27 +51,31 @@ def execute_cmd(keyspace, send_fn, cmd, *args):
         transmit(send_fn, result)
 
 
-def transmit(send_fn, result):
-    to_send = []
+def transform(obj):
+    result = []
 
     def _transform(elem):
         if elem is None:
-            to_send.append('$-1\r\n')
+            result.append('$-1\r\n')
         elif isinstance(elem, int):
-            to_send.append(':{}\r\n'.format(elem))
+            result.append(':{}\r\n'.format(elem))
         elif isinstance(elem, SimpleString):
-            to_send.append('+{}\r\n'.format(elem))
+            result.append('+{}\r\n'.format(elem))
         elif isinstance(elem, basestring):
-            to_send.append('${}\r\n{}\r\n'.format(len(elem), elem))
+            result.append('${}\r\n{}\r\n'.format(len(elem), elem))
         elif isinstance(elem, (set, list, tuple)):
-            to_send.append('*{}\r\n'.format(len(elem)))
+            result.append('*{}\r\n'.format(len(elem)))
             for element in elem:
                 _transform(element)
         else:
-            assert False, 'couldnt catch a response for {} (type {})'.format(repr(result), type(result))
+            assert False, 'couldnt catch a response for {} (type {})'.format(repr(elem), type(elem))
 
-    _transform(result)
-    send_fn(''.join(to_send))
+    _transform(obj)
+    return ''.join(result)
+
+
+def transmit(send_fn, result):
+    send_fn(transform(result))
 
 
 class CommandHandler(asyncore.dispatcher):

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,4 +1,4 @@
-from dredis.server import transmit
+from dredis.server import transmit, transform
 import mock
 
 
@@ -8,31 +8,25 @@ def test_transmit_integer():
     mock_function.assert_called_with(':1\r\n')
 
 
-def test_transmit_bulk_string():
-    mock_function = mock.Mock()
-    transmit(mock_function, "test")
-    mock_function.assert_called_with('$4\r\ntest\r\n')
+def test_transform_integer():
+    assert transform(1) == ':1\r\n'
 
 
-def test_transmit_nil():
-    mock_function = mock.Mock()
-    transmit(mock_function, None)
-    mock_function.assert_called_with('$-1\r\n')
+def test_transform_bulk_string():
+    assert transform("test") == '$4\r\ntest\r\n'
 
 
-def test_transmit_simple_array():
-    mock_function = mock.Mock()
-    transmit(mock_function, ['1', '2'])
-    mock_function.assert_called_with('*2\r\n$1\r\n1\r\n$1\r\n2\r\n')
+def test_transform_nil():
+    assert transform(None) == '$-1\r\n'
 
 
-def test_transmit_mixed_array():
-    mock_function = mock.Mock()
-    transmit(mock_function, ['1', 2, None])
-    mock_function.assert_called_with('*3\r\n$1\r\n1\r\n:2\r\n$-1\r\n')
+def test_transform_simple_array():
+    assert transform(['1', '2']) == '*2\r\n$1\r\n1\r\n$1\r\n2\r\n'
 
 
-def test_transmit_nested_array():
-    mock_function = mock.Mock()
-    transmit(mock_function, ['1', 3, ['2']])
-    mock_function.assert_called_with('*3\r\n$1\r\n1\r\n:3\r\n*1\r\n$1\r\n2\r\n')
+def test_transform_mixed_array():
+    assert transform(['1', 2, None]) == '*3\r\n$1\r\n1\r\n:2\r\n$-1\r\n'
+
+
+def test_transform_nested_array():
+    assert transform(['1', 3, ['2']]) == '*3\r\n$1\r\n1\r\n:3\r\n*1\r\n$1\r\n2\r\n'

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,0 +1,38 @@
+from dredis.server import transmit
+import mock
+
+
+def test_transmit_integer():
+    mock_function = mock.Mock()
+    transmit(mock_function, 1)
+    mock_function.assert_called_with(':1\r\n')
+
+
+def test_transmit_bulk_string():
+    mock_function = mock.Mock()
+    transmit(mock_function, "test")
+    mock_function.assert_called_with('$4\r\ntest\r\n')
+
+
+def test_transmit_nil():
+    mock_function = mock.Mock()
+    transmit(mock_function, None)
+    mock_function.assert_called_with('$-1\r\n')
+
+
+def test_transmit_simple_array():
+    mock_function = mock.Mock()
+    transmit(mock_function, ['1', '2'])
+    mock_function.assert_called_with('*2\r\n$1\r\n1\r\n$1\r\n2\r\n')
+
+
+def test_transmit_mixed_array():
+    mock_function = mock.Mock()
+    transmit(mock_function, ['1', 2, None])
+    mock_function.assert_called_with('*3\r\n$1\r\n1\r\n:2\r\n$-1\r\n')
+
+
+def test_transmit_nested_array():
+    mock_function = mock.Mock()
+    transmit(mock_function, ['1', 3, ['2']])
+    mock_function.assert_called_with('*3\r\n$1\r\n1\r\n:3\r\n*1\r\n$1\r\n2\r\n')

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -30,3 +30,7 @@ def test_transform_mixed_array():
 
 def test_transform_nested_array():
     assert transform(['1', 3, ['2']]) == '*3\r\n$1\r\n1\r\n:3\r\n*1\r\n$1\r\n2\r\n'
+
+
+def test_transform_error():
+    assert transform(Exception('test')) == '-ERR test\r\n'


### PR DESCRIPTION
Refactored the `transmit` function into two separate functions, `transmit` and `transform`. Added unit tests for both functions. Simplified how errors are handled and made them use the `transmit` function. 