### PR TITLE
Add support to LMDB and make it the default backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,13 @@ The current default options for LevelDB are:
 ### LMDB
 
 The performance of LMDB can be better than LevelDB and we're considering making it the default backend in the future.
-We use [py-lmdb](https://github.com/dw/py-lmdb/) as the LMDB backend. All available options are parameters of [lmdb.Environment](https://lmdb.readthedocs.io/en/release/#environment-class).
-We recommend that you think ahead and change the `map_size` parameter according to your needs — this is the maximum size of the LMDB database file on disk.
 
 #### Options
 
+We use [py-lmdb](https://github.com/dw/py-lmdb/) as the LMDB backend. All available options are parameters of [lmdb.Environment](https://lmdb.readthedocs.io/en/release/#environment-class).
+We recommend that you think ahead and change the `map_size` parameter according to your needs — this is the maximum size of the LMDB database file on disk.
+
+The current default options for LMDB are:
 * `path`: The same value as the `--dir` option
 * `map_size`: `1073741824` (1GB)
 * `map_async`: `True`

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ dredis --dir /tmp/dredis-data
 To know about all of the options, use `--help`:
 
 ```shell
+$ dredis --help
 usage: dredis [-h] [-v] [--host HOST] [--port PORT] [--dir DIR]
               [--backend {lmdb,leveldb,memory}]
               [--backend-option BACKEND_OPTION] [--debug] [--flushall]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Make sure to install the [LevelDB](https://github.com/google/leveldb) C++ librar
 $ pip install dredis
 ```
 
+Note: The LMDB backend doesn't require external dependencies.
+
 ## Running
 
 
@@ -26,26 +28,74 @@ $ dredis --dir /tmp/dredis-data
 To know about all of the options, use `--help`:
 
 ```shell
-$ dredis --help
-usage: dredis [-h] [-v] [--host HOST] [--port PORT] [--dir DIR] [--debug]
-              [--flushall]
+usage: dredis [-h] [-v] [--host HOST] [--port PORT] [--dir DIR]
+              [--backend {lmdb,leveldb,memory}]
+              [--backend-option BACKEND_OPTION] [--debug] [--flushall]
 
 optional arguments:
-  -h, --help     show this help message and exit
-  -v, --version  show program's version number and exit
-  --host HOST    server host (defaults to 127.0.0.1)
-  --port PORT    server port (defaults to 6377)
-  --dir DIR      directory to save data (defaults to a temporary directory)
-  --debug        enable debug logs
-  --flushall     run FLUSHALL on startup
+  -h, --help            show this help message and exit
+  -v, --version         show program's version number and exit
+  --host HOST           server host (defaults to 127.0.0.1)
+  --port PORT           server port (defaults to 6377)
+  --dir DIR             directory to save data (defaults to a temporary
+                        directory)
+  --backend {lmdb,leveldb,memory}
+                        key/value database backend (defaults to leveldb)
+  --backend-option BACKEND_OPTION
+                        database backend options (e.g., --backend-option
+                        map_size=BYTES)
+  --debug               enable debug logs
+  --flushall            run FLUSHALL on startup
 ```
 
 
-If you want to try it with docker locally (port 6377 on the host):
+Running dredis with Docker locally (port 6377 on the host):
 
 ```shell
 $ docker-compose up
 ```
+
+
+
+## Backends
+
+There's support for LevelDB, LMDB, and an experimental memory backend.
+All backend options should be passed in the command line as `--backend-option NAME1=value1 --backend-option NAME2=value2` (the values must be JSON-compatible).
+
+### LevelDB
+LevelDB is the easiest persistent backend because it doesn't require any option tweaking to get it to work reliably.
+
+#### Options
+
+We use [plyvel](https://github.com/wbolster/plyvel) as the LevelDB backend. All available options are parameters of [plyvel.DB](https://plyvel.readthedocs.io/en/latest/api.html#DB).
+
+The current default options for LevelDB are:
+* `name`: The same value as the `--dir` option
+* `create_if_missing`: `True`
+
+
+### LMDB
+
+The performance of LMDB can be better than LevelDB and we're considering making it the default backend in the future.
+We use [py-lmdb](https://github.com/dw/py-lmdb/) as the LMDB backend. All available options are parameters of [lmdb.Environment](https://lmdb.readthedocs.io/en/release/#environment-class).
+We recommend that you think ahead and change the `map_size` parameter according to your needs — this is the maximum size of the LMDB database file on disk.
+
+#### Options
+
+* `path`: The same value as the `--dir` option
+* `map_size`: `1073741824` (1GB)
+* `map_async`: `True`
+* `writemap`: `True`
+* `readahead`: `False`
+* `metasync`: `False`
+
+### Memory
+
+This is experimental and doesn't persist to disk. It was created to have a baseline to compare persistent backends.
+
+
+#### Options
+None.
 
 
 ## Supported Commands
@@ -91,12 +141,12 @@ HLEN key                                     | Hashes
 HINCRBY key field increment                  | Hashes
 HGETALL key                                  | Hashes
 
-\* `COMMAND`'s reply is incompatible at the moment, it returns a flat array with command names (their arity, flags, positions, or step count are not returned). 
+\* `COMMAND`'s reply is incompatible at the moment, it returns a flat array with command names (their arity, flags, positions, or step count are not returned).
 
 
 ## How is DRedis implemented
 
-Initially DRedis had its own filesystem structure, but then it was converted to use [LevelDB](https://github.com/google/leveldb), which is a lot more reliable and faster.
+Initially DRedis had its own filesystem structure, but then it was converted to use [LevelDB](https://github.com/google/leveldb), which is a lot more reliable and faster (nowadays there's also the LMDB backend).
 Other projects implement similar features to what's available on DRedis, but they aren't what Yipit needed when the project started.
 Some similar projects follow:
 
@@ -117,7 +167,7 @@ Lua is supported through the [lupa](https://github.com/scoder/lupa) library.
 
 ### Data Consistency
 
-We are relying on LevelDB's consistency, no stress tests were performed.
+We rely on the backends' consistency properties and we use batches/transactions to stay consistent. Tweaking the backend options may impair consistency (e.g., `sync=false` for LMDB).
 
 ### Cluster mode & Replication
 
@@ -128,13 +178,9 @@ Use DNS routing or a network load balancer to route requests properly.
 ### Backups
 
 There are many solutions to back up files. DRedis will have no impact when backups are performed because it's done from the outside (different from Redis, which uses `fork()` to snapshot the data).
-A straightforward approach is to have period backups to an object storage such as Amazon S3.
+A straightforward approach is to have periodic backups to an object storage such as Amazon S3 orr use a block storage solution and perform periodic backups (e.g., AWS EBS).
 
-The commands SAVE or BGSAVE will be supported in the future to guarantee consistency when generating backups.
-
-This project includes a snapshot utility (`dredis-snapshot`) to make it easier to back up data locally or to AWS S3.
-Be aware that there may be consistency issues during the snapshot (`dredis` won't pause during the temporary copy of the data directory).
-
+The commands SAVE or BGSAVE may be supported in the future.
 
 ## Why Python
 

--- a/dredis/db.py
+++ b/dredis/db.py
@@ -238,7 +238,7 @@ DB_BACKENDS = {
     'lmdb': LMDBBackend,
     'memory': MemoryBackend,
 }
-DEFAULT_DB_BACKEND = 'lmdb'
+DEFAULT_DB_BACKEND = 'leveldb'
 
 
 class DBManager(object):

--- a/dredis/db.py
+++ b/dredis/db.py
@@ -130,6 +130,7 @@ class LMDBBackend(object):
             'map_async': True,
             'writemap': True,
             'readahead': False,
+            'metasync': False,
         }
         options = default_options.copy()
         options.update(custom_options)

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -1,7 +1,7 @@
 import collections
 import fnmatch
 
-from dredis.ldb import LEVELDB, LDB_KEY_TYPES, KEY_CODEC
+from dredis.ldb import LEVELDB, KEY_CODEC
 from dredis.lua import LuaRunner
 from dredis.utils import to_float
 
@@ -330,7 +330,7 @@ class Keyspace(object):
         level_db_keys = set()
         for key, _ in self._ldb:
             key_type, _, key_value = KEY_CODEC.decode_key(key)
-            if key_type not in LDB_KEY_TYPES:
+            if key_type not in KEY_CODEC.KEY_TYPES:
                 continue
             if pattern is None or fnmatch.fnmatch(key_value, pattern):
                 level_db_keys.add(key_value)

--- a/dredis/ldb.py
+++ b/dredis/ldb.py
@@ -106,11 +106,11 @@ class LMDBBatch(object):
         self._delete.add(key)
 
     def write(self):
-        with self._env.begin(write=True) as t:
+        with self._env.begin(write=True) as tnx:
             for k, v in self._put.items():
-                t.put(k, v)
+                tnx.put(k, v)
             for k in self._delete:
-                t.delete(k)
+                tnx.delete(k)
 
     def __enter__(self):
         return self
@@ -131,16 +131,16 @@ class LMDBWrapper(object):
         self._env = lmdb.open(path, map_size=100*GB, map_async=True, writemap=True)
 
     def get(self, key, default=None):
-        with self._env.begin() as t:
-            return t.get(key, default)
+        with self._env.begin() as tnx:
+            return tnx.get(key, default)
 
     def put(self, key, value):
-        with self._env.begin(write=True) as t:
-            t.put(key, value)
+        with self._env.begin(write=True) as tnx:
+            tnx.put(key, value)
 
     def delete(self, key):
-        with self._env.begin(write=True) as t:
-            t.delete(key)
+        with self._env.begin(write=True) as tnx:
+            tnx.delete(key)
 
     def write_batch(self):
         return LMDBBatch(self._env)

--- a/dredis/ldb.py
+++ b/dredis/ldb.py
@@ -151,7 +151,7 @@ class LMDBWrapper(object):
     def iterator(self, prefix='', include_value=True):
         with self._env.begin() as t:
             c = t.cursor()
-            if not c.set_range(prefix):
+            if prefix and not c.set_range(prefix):
                 return
             for k, v in c:
                 if not k.startswith(prefix):

--- a/dredis/parser.py
+++ b/dredis/parser.py
@@ -27,7 +27,7 @@ class Parser(object):
         result = self._buffer[self._buffer_pos:][:n_bytes]
         # FIXME: ensure self.CRLF is next
         self._buffer_pos += n_bytes + len(self.CRLF)
-        return str(result)
+        return result
 
     def get_instructions(self):
         self._read_into_buffer()
@@ -38,7 +38,7 @@ class Parser(object):
             # Redis's own tests have commands like PING being sent as a Simple String
             if instructions.startswith('+'):
                 self._buffer = self._buffer[self._buffer_pos:]
-                yield instructions[1:].strip().split()
+                yield str(instructions[1:].strip()).split()
             elif instructions.startswith('*'):
                 # array of instructions
                 array_length = int(instructions[1:])  # skip '*' char
@@ -46,7 +46,7 @@ class Parser(object):
                 for _ in range(array_length):
                     line = self._readline()
                     str_len = int(line[1:])  # skip '$' char
-                    instruction = self._read(str_len)
+                    instruction = str(self._read(str_len))
                     instruction_set.append(instruction)
                 self._buffer = self._buffer[self._buffer_pos:]
                 yield instruction_set
@@ -54,4 +54,4 @@ class Parser(object):
                 # inline instructions, saw them in the Redis tests
                 for line in instructions.split(self.CRLF):
                     self._buffer = self._buffer[self._buffer_pos:]
-                    yield line.strip().split()
+                    yield str(line.strip()).split()

--- a/dredis/parser.py
+++ b/dredis/parser.py
@@ -4,7 +4,7 @@ class Parser(object):
     CRLF = '\r\n'
 
     def __init__(self, read_fn):
-        self._buffer = ""
+        self._buffer = bytearray()
         self._buffer_pos = 0
         self._read_fn = read_fn
 
@@ -19,7 +19,7 @@ class Parser(object):
     def _read_into_buffer(self):
         # FIXME: implement a maximum size for the buffer to prevent a crash due to bad clients
         data = self._read_fn(self.MAX_BUFSIZE)
-        self._buffer += data
+        self._buffer.extend(data)
 
     def _read(self, n_bytes):
         if len(self._buffer[self._buffer_pos:]) < n_bytes:
@@ -27,7 +27,7 @@ class Parser(object):
         result = self._buffer[self._buffer_pos:][:n_bytes]
         # FIXME: ensure self.CRLF is next
         self._buffer_pos += n_bytes + len(self.CRLF)
-        return result
+        return str(result)
 
     def get_instructions(self):
         self._read_into_buffer()

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -12,7 +12,7 @@ import sys
 from dredis import __version__
 from dredis.commands import run_command, SimpleString, CommandNotFound
 from dredis.keyspace import Keyspace
-from dredis.ldb import LEVELDB
+from dredis.db import DB_MANAGER
 from dredis.lua import RedisScriptError
 from dredis.parser import Parser
 from dredis.path import Path
@@ -153,7 +153,7 @@ def main():
     else:
         setup_logging(logging.INFO)
 
-    LEVELDB.setup_dbs(ROOT_DIR)
+    DB_MANAGER.setup_dbs(ROOT_DIR)
     keyspace = Keyspace()
     if args.flushall:
         keyspace.flushall()

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -10,9 +10,9 @@ import traceback
 import sys
 
 from dredis import __version__
+from dredis import db
 from dredis.commands import run_command, SimpleString, CommandNotFound
 from dredis.keyspace import Keyspace
-from dredis.db import DB_MANAGER
 from dredis.lua import RedisScriptError
 from dredis.parser import Parser
 from dredis.path import Path
@@ -136,6 +136,8 @@ def main():
     parser.add_argument('--port', default='6377', type=int, help='server port (defaults to %(default)s)')
     parser.add_argument('--dir', default=None,
                         help='directory to save data (defaults to a temporary directory)')
+    parser.add_argument('--backend', default=db.DEFAULT_DB_BACKEND, choices=db.DB_BACKENDS.keys(),
+                        help='key/value database backend (defaults to %(default)s)')
     parser.add_argument('--debug', action='store_true', help='enable debug logs')
     parser.add_argument('--flushall', action='store_true', default=False, help='run FLUSHALL on startup')
     args = parser.parse_args()
@@ -153,13 +155,14 @@ def main():
     else:
         setup_logging(logging.INFO)
 
-    DB_MANAGER.setup_dbs(ROOT_DIR)
+    db.DB_MANAGER.setup_dbs(ROOT_DIR, args.backend)
     keyspace = Keyspace()
     if args.flushall:
         keyspace.flushall()
 
     RedisServer(args.host, args.port)
 
+    logger.info("Backend: {}".format(args.backend))
     logger.info("Port: {}".format(args.port))
     logger.info("Root directory: {}".format(ROOT_DIR))
     logger.info('PID: {}'.format(os.getpid()))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 lupa
 six
 plyvel
+lmdb

--- a/tests/integration/test_leveldb.py
+++ b/tests/integration/test_leveldb.py
@@ -6,7 +6,7 @@ from dredis.db import DB_MANAGER
 
 def test_delete():
     tempdir = tempfile.mkdtemp(prefix="redis-test-")
-    DB_MANAGER.setup_dbs(tempdir, backend='leveldb')
+    DB_MANAGER.setup_dbs(tempdir, backend='leveldb', backend_options={})
     keyspace = Keyspace()
 
     keyspace.select('0')

--- a/tests/integration/test_leveldb.py
+++ b/tests/integration/test_leveldb.py
@@ -1,12 +1,12 @@
 import tempfile
 
 from dredis.keyspace import Keyspace
-from dredis.ldb import LEVELDB
+from dredis.db import DB_MANAGER
 
 
 def test_delete():
     tempdir = tempfile.mkdtemp(prefix="redis-test-")
-    LEVELDB.setup_dbs(tempdir)
+    DB_MANAGER.setup_dbs(tempdir)
     keyspace = Keyspace()
 
     keyspace.select('0')
@@ -17,4 +17,4 @@ def test_delete():
 
     keyspace.delete('mystr', 'myset', 'myzset', 'myhash', 'notfound')
 
-    assert list(LEVELDB.get_db('0').iterator()) == []
+    assert list(DB_MANAGER.get_db('0').iterator()) == []

--- a/tests/integration/test_leveldb.py
+++ b/tests/integration/test_leveldb.py
@@ -6,7 +6,7 @@ from dredis.db import DB_MANAGER
 
 def test_delete():
     tempdir = tempfile.mkdtemp(prefix="redis-test-")
-    DB_MANAGER.setup_dbs(tempdir)
+    DB_MANAGER.setup_dbs(tempdir, backend='leveldb')
     keyspace = Keyspace()
 
     keyspace.select('0')


### PR DESCRIPTION
We should increment the major version because this is a backward incompatible change. It's still possible to use leveldb, but it's no longer the default (`--backend leveldb`). We can argue about this being the default choice and even revert the change, but I will justify why LMDB is better than LevelDB for our main scenario, which is supporting [Readypipe](https://readypipe.com/) on Linux servers.



## How to review this PR

I recommend reviewing commit by commit, from oldest to newest. FYI:
* The most important commit is https://github.com/Yipit/dredis/commit/bae387582034145669a614f064447f975a54c510, which introduces `LMDBWrapper` with a similar interface to `plyvel.DB`
* Some optimizations to LevelDB are included in this PR and LMDB takes advantage of them (https://github.com/Yipit/dredis/commit/af2402bd928c9910dd826cd7c5f08a1f20e8aea9, https://github.com/Yipit/dredis/commit/56d911665052785628e5827f0369228d9244d183, https://github.com/Yipit/dredis/commit/81856db0715b0a74d87bc00182d248906b9c0b0d)
* The `MemoryBackend` class was introduced to help me have a baseline for some local benchmarks (https://github.com/Yipit/dredis/commit/33c79b444883c6fa7297f95f41c873f028d5b5ce)

## The default backend is now LMDB

All the benchmarks were done on Ubuntu 16.04 on EC2, but LevelDB performed better than LMDB on my MacBook Pro 2017, it may be because of the filesystem. It's possible that we need more benchmarks before switching to LMDB as the default. The latency I observed with a Readypipe project in a staging environment was much better.


## Readypipe performance benchmarks

DRedis is being built to support [Readypipe](https://readypipe.com) and I tested its performance by filling a queue with ~4 million items (`starting_task`) and then using 400 numprocs for the `subtask`.


### Server setup

DRedis version: 1.0.2 for LevelDB and commit https://github.com/Yipit/dredis/commit/403e10 for LMDB
Server: EC2 m5.large
Disk: 20GB gp2, EXT4


### Benchmark code

```python
import random
import datetime
from readypipe import rp_product, starting_task, subtask, schedule_many, main


@starting_task
def start():
    i = int(random.random() * 100_000_000)
    while True:
        step = int(random.random() * 5_000_000)
        now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
        params = [{'data': x, 'bundled_data': {'double': x*2, 'now': now}} for x in range(i, i + step)]
        schedule_many('task', params)
        i += step

@subtask
def task(index):
    bundled_data = rp_product.get_bundle_from_data()
    import time
    time.sleep(random.random() * 0.150)  # fake processing time
    if random.random() < 0.1:
        return 300  # reschedule items once in a while
    else:
        return


if __name__ == '__main__':
    main()
```

### LMDB results

~150ms upper_90

![Screen Shot 2019-05-24 at 4 36 53 PM](https://user-images.githubusercontent.com/61387/58355752-67269080-7e43-11e9-9dd3-09768a16ffd3.png)
 


### LevelDB results

~650ms upper_90

![Screen Shot 2019-05-24 at 1 02 22 PM](https://user-images.githubusercontent.com/61387/58355750-64c43680-7e43-11e9-8710-87a9b9c0d161.png)

--------

There are other benchmarks that we can do, but this seems to be enough to justify using LMDB over LevelDB for Readypipe.