### PR TITLE
Refactor rdb.py to have two symmetrical classes to load & dump data

### DIFF
--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -438,11 +438,7 @@ class Keyspace(object):
         return DB_MANAGER.get_db(self._current_db)
 
     def dump(self, key):
-        key_type = self.type(key)
-        if key_type == 'none':
-            return None
-        else:
-            return rdb.generate_payload(self, key, key_type)
+        return rdb.generate_payload(self, key)
 
     def restore(self, key, ttl, payload, replace):
         # TODO: there's no TTL support at the moment

--- a/dredis/rdb.py
+++ b/dredis/rdb.py
@@ -32,84 +32,6 @@ RDB_VERSION = 7
 BAD_DATA_FORMAT_ERR = ValueError("Bad data format")
 
 
-def object_type(type_name):
-    """
-    :return: little endian encoded type
-    """
-    return struct.pack('<B', RDB_TYPES[type_name])
-
-
-def object_value(keyspace, key, key_type):
-    if key_type == 'string':
-        string = keyspace.get(key)
-        return save_raw_string(string)
-    elif key_type == 'set':
-        members = keyspace.smembers(key)
-        length = len(members)
-        result = save_len(length)
-        for member in members:
-            result += save_raw_string(member)
-        return result
-    elif key_type == 'hash':
-        keys_and_values = keyspace.hgetall(key)
-        length = len(keys_and_values) / 2
-        result = save_len(length)
-        while keys_and_values:
-            hash_key = keys_and_values.pop(0)
-            hash_value = keys_and_values.pop(0)
-            result += save_raw_string(hash_key)
-            result += save_raw_string(hash_value)
-        return result
-    elif key_type == 'zset':
-        values_and_scores = keyspace.zrange(key, 0, -1, with_scores=True)
-        length = len(values_and_scores) / 2
-        result = save_len(length)
-        while values_and_scores:
-            value = values_and_scores.pop(0)
-            score = values_and_scores.pop(0)
-            result += save_raw_string(value)
-            result += save_double(score)
-        return result
-    raise ValueError("Can't convert %r" % key_type)
-
-
-def save_raw_string(string):
-    return save_len(len(string)) + string
-
-
-def save_len(len):
-    """
-    :return: big endian encoded length
-
-    Original: https://github.com/antirez/redis/blob/3.2.6/src/rdb.c
-
-    """
-    if len < (1 << 6):
-        return struct.pack('>B', (len & 0xFF) | (RDB_6BITLEN << 6))
-    elif len < (1 << 14):
-        return struct.pack('>BB', ((len >> 8) & 0xFF) | (RDB_14BITLEN << 6), len & 0xFF)
-    else:
-        return struct.pack('>BL', (RDB_32BITLEN << 6), len)
-
-
-def save_double(number):
-    """
-    :return: big endian encoded float. 255 represents -inf, 244 +inf, 253 NaN
-
-    This function is based on rdbSaveDoubleValue() from rdb.c
-    """
-    number = float(number)
-    if number == float('-inf'):
-        return struct.pack('>B', 255)
-    elif number == float('+inf'):
-        return struct.pack('>B', 254)
-    elif number == float('nan'):
-        return struct.pack('>B', 253)
-    else:
-        string = '%.17g' % float(number)
-        return struct.pack('>B', len(string)) + string
-
-
 def get_rdb_version():
     """
     :return: little endian encoded 2-byte RDB version
@@ -120,6 +42,38 @@ def get_rdb_version():
 def load_object(keyspace, key, payload):
     object_loader = ObjectLoader(keyspace, payload)
     object_loader.load(key)
+
+
+def generate_payload(keyspace, key):
+    key_type = keyspace.type(key)
+    if key_type == 'none':
+        return None
+    else:
+        object_dumper = ObjectDumper(keyspace)
+        payload = (
+                object_dumper.dump_type(key_type) +
+                object_dumper.dump(key, key_type) +
+                get_rdb_version()
+        )
+        checksum = crc64.checksum(payload)
+        return payload + checksum
+
+
+def verify_payload(payload):
+    bad_payload = ValueError('DUMP payload version or checksum are wrong')
+    if len(payload) < 10:
+        raise bad_payload
+    data, footer = payload[:-10], payload[-10:]
+    rdb_version, crc = footer[:2], footer[2:]
+    if rdb_version > get_rdb_version():
+        raise bad_payload
+    if crc64.checksum(data + rdb_version) != crc:
+        raise bad_payload
+
+
+# NOTE: The classes ObjectLoader and ObjectDumper are symmetrical.
+# any changes to one of their public methods should affect the other class's equivalent method.
+# All of the `ObjectLoader.load*` and `ObjectDumper.dump*` methods are coupled!
 
 
 class ObjectLoader(object):
@@ -134,7 +88,7 @@ class ObjectLoader(object):
         data = self.payload[:-10]  # ignore the RDB header (2 bytes) and the CRC64 checksum (8 bytes)
         if not data:
             raise BAD_DATA_FORMAT_ERR
-        obj_type = self.get_type(data)
+        obj_type = self.load_type(data)
         if obj_type == RDB_TYPE_STRING:
             self.load_string(key, data[1:])
         elif obj_type == RDB_TYPE_SET:
@@ -147,27 +101,27 @@ class ObjectLoader(object):
             raise BAD_DATA_FORMAT_ERR
 
     def load_string(self, key, data):
-        obj = self._read_string(data)
+        obj = self._load_string(data)
         self.keyspace.set(key, obj)
 
     def load_set(self, key, data):
         length = self.load_len(data)
         for _ in xrange(length):
-            elem = self._read_string(data)
+            elem = self._load_string(data)
             self.keyspace.sadd(key, elem)
 
     def load_zset(self, key, data):
         length = self.load_len(data)
         for _ in xrange(length):
-            value = self._read_string(data)
+            value = self._load_string(data)
             score = self.load_double(data)
             self.keyspace.zadd(key, score, value)
 
     def load_hash(self, key, data):
         length = self.load_len(data)
         for _ in xrange(length):
-            field = self._read_string(data)
-            value = self._read_string(data)
+            field = self._load_string(data)
+            value = self._load_string(data)
             self.keyspace.hset(key, field, value)
 
     def load_double(self, data):
@@ -183,9 +137,6 @@ class ObjectLoader(object):
             result = float(data[self.index:self.index + length])
             self.index += length
         return result
-
-    def get_type(self, data):
-        return struct.unpack('<B', data[0])[0]
 
     def load_len(self, data):
         """
@@ -215,30 +166,102 @@ class ObjectLoader(object):
             raise BAD_DATA_FORMAT_ERR
         return length
 
-    def _read_string(self, data):
+    def load_type(self, data):
+        return struct.unpack('<B', data[0])[0]
+
+    def _load_string(self, data):
         length = self.load_len(data)
         obj = data[self.index:self.index + length]
         self.index += length
         return obj
 
 
-def generate_payload(keyspace, key, key_type):
-    payload = (
-        object_type(key_type) +
-        object_value(keyspace, key, key_type) +
-        get_rdb_version()
-    )
-    checksum = crc64.checksum(payload)
-    return payload + checksum
+class ObjectDumper(object):
 
+    def __init__(self, keyspace):
+        self.keyspace = keyspace
 
-def verify_payload(payload):
-    bad_payload = ValueError('DUMP payload version or checksum are wrong')
-    if len(payload) < 10:
-        raise bad_payload
-    data, footer = payload[:-10], payload[-10:]
-    rdb_version, crc = footer[:2], footer[2:]
-    if rdb_version > get_rdb_version():
-        raise bad_payload
-    if crc64.checksum(data + rdb_version) != crc:
-        raise bad_payload
+    def dump(self, key, key_type):
+        if key_type == 'string':
+            return self.dump_string(key)
+        if key_type == 'set':
+            return self.dump_set(key)
+        if key_type == 'hash':
+            return self.dump_hash(key)
+        if key_type == 'zset':
+            return self.dump_zset(key)
+        raise ValueError("Can't convert %r" % key_type)
+
+    def dump_string(self, key):
+        string = self.keyspace.get(key)
+        return self._dump_string(string)
+
+    def dump_set(self, key):
+        members = self.keyspace.smembers(key)
+        length = len(members)
+        result = self.dump_length(length)
+        for member in members:
+            result += self._dump_string(member)
+        return result
+
+    def dump_hash(self, key):
+        keys_and_values = self.keyspace.hgetall(key)
+        length = len(keys_and_values) / 2
+        result = self.dump_length(length)
+        while keys_and_values:
+            hash_key = keys_and_values.pop(0)
+            hash_value = keys_and_values.pop(0)
+            result += self._dump_string(hash_key)
+            result += self._dump_string(hash_value)
+        return result
+
+    def dump_zset(self, key):
+        values_and_scores = self.keyspace.zrange(key, 0, -1, with_scores=True)
+        length = len(values_and_scores) / 2
+        result = self.dump_length(length)
+        while values_and_scores:
+            value = values_and_scores.pop(0)
+            score = values_and_scores.pop(0)
+            result += self._dump_string(value)
+            result += self.dump_double(score)
+        return result
+
+    def dump_length(self, len):
+        """
+        :return: big endian encoded length
+
+        Original: https://github.com/antirez/redis/blob/3.2.6/src/rdb.c
+
+        """
+        if len < (1 << 6):
+            return struct.pack('>B', (len & 0xFF) | (RDB_6BITLEN << 6))
+        elif len < (1 << 14):
+            return struct.pack('>BB', ((len >> 8) & 0xFF) | (RDB_14BITLEN << 6), len & 0xFF)
+        else:
+            return struct.pack('>BL', (RDB_32BITLEN << 6), len)
+
+    def dump_double(self, number):
+        """
+        :return: big endian encoded float. 255 represents -inf, 244 +inf, 253 NaN
+
+        This function is based on rdbSaveDoubleValue() from rdb.c
+        """
+        number = float(number)
+        if number == float('-inf'):
+            return struct.pack('>B', 255)
+        elif number == float('+inf'):
+            return struct.pack('>B', 254)
+        elif number == float('nan'):
+            return struct.pack('>B', 253)
+        else:
+            string = '%.17g' % float(number)
+            return struct.pack('>B', len(string)) + string
+
+    def dump_type(self, key_type):
+        """
+        :return: little endian encoded type
+        """
+        return struct.pack('<B', RDB_TYPES[key_type])
+
+    def _dump_string(self, string):
+        return self.dump_length(len(string)) + string


### PR DESCRIPTION
This PR moves the load logic to `ObjectLoader` and the dump logic to `ObjectDumper`. The two classes have the same set of public methods and should remain coupled for their entire lifetime. 
`ObjectLoader.load*` methods are equivalent to `ObjectDumper.dump*` methods.

