### PR TITLE
Optimize KEYS runtime

### DIFF
--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -328,12 +328,11 @@ class Keyspace(object):
 
     def keys(self, pattern):
         db_keys = set()
-        for key, _ in self._db:
-            key_type, _, key_value = KEY_CODEC.decode_key(key)
-            if key_type not in KEY_CODEC.KEY_TYPES:
-                continue
-            if pattern is None or fnmatch.fnmatch(key_value, pattern):
-                db_keys.add(key_value)
+        for key_type in KEY_CODEC.KEY_TYPES:
+            for key in self._db.iterator(prefix=chr(key_type), include_value=False):
+                _, _, key_value = KEY_CODEC.decode_key(key)
+                if pattern is None or fnmatch.fnmatch(key_value, pattern):
+                    db_keys.add(key_value)
         return db_keys
 
     def dbsize(self):


### PR DESCRIPTION
Before this PR the runtime of KEYS was `O(n)` and `n` was the total number of lower level keys stored in the backend. This pull request uses the prefixes to have better performance and only look at the lower level keys that match the right prefix. It's `O(n)`, but `n` now is the number of keys in the keyspace instead of keys in the backend.