### PR TITLE
Fix negative score order (backward incompatible!)

### DIFF
--- a/dredis/utils.py
+++ b/dredis/utils.py
@@ -1,6 +1,56 @@
+import struct
+
+
 def to_float(s):
     # Redis uses `strtod` which converts empty string to 0
     if s == '':
         return 0
     else:
         return float(s)
+
+
+class FloatCodec(object):
+    """
+    FloatCode encodes `float` objects to bytes and preserve their numerical order.
+    For example, the following list is encoded to bytes while keeping and preserves its numerical order:
+    >>> floats = [1.5, -2.5, 3.2, 2.0]
+    >>> sorted(floats, key=FloatCodec().encode)
+    [-2.5, 1.5, 2.0, 3.2]
+
+    References:
+    * https://en.wikipedia.org/wiki/Floating-point_arithmetic#IEEE_754_design_rationale
+    * https://stackoverflow.com/a/43305015/565999
+    * https://stackoverflow.com/a/12933766/565999
+    * https://ananthakumaran.in/2018/08/17/order-preserving-serialization.html#float
+    * https://github.com/apple/foundationdb/blob/b92e6b09ad67fa382e17500536fd13b10bb23ede/design/tuple.md#ieee-binary-floating-point
+    """
+
+    STRUCT = struct.Struct('>d')
+
+    def encode(self, score):
+        score_bytes = bytearray(self.STRUCT.pack(score))
+        # if a negative number, flip all bits
+        if score_bytes[0] & 0x80 != 0x00:
+            score_bytes = self._flip_bits(score_bytes)
+        else:
+            # flip the sign if it's a positive number
+            score_bytes[0] ^= 0x80  # flip the sign
+        return bytes(score_bytes)
+
+    def decode(self, bytestring):
+        score_bytes = bytearray(bytestring)
+        # if a negative number, flip all bits
+        if score_bytes[0] & 0x80 != 0x80:
+            score_bytes = self._flip_bits(score_bytes)
+        else:
+            # flip the sign if it's a positive number
+            score_bytes[0] ^= 0x80  # flip the sign
+        return self.STRUCT.unpack(score_bytes)[0]
+
+    def _flip_bits(self, bytestring):
+        for i in xrange(len(bytestring)):
+            bytestring[i] ^= 0xff
+        return bytestring
+
+
+FLOAT_CODEC = FloatCodec()

--- a/tests/integration/test_zset.py
+++ b/tests/integration/test_zset.py
@@ -23,7 +23,7 @@ def test_zadd_with_multiple_parameters():
     assert r.zcard('myzset') == 3
 
 
-def test_zset_zrange_with_positive_integers():
+def test_zset_zrange_with_positive_indexes():
     r = fresh_redis()
     r.zadd('myzset', 0, 'myvalue1')
     r.zadd('myzset', 1, 'myvalue2')
@@ -31,7 +31,7 @@ def test_zset_zrange_with_positive_integers():
     assert r.zrange('myzset', 0, 100) == ['myvalue1', 'myvalue2']
 
 
-def test_zset_zrange_with_negative_numbers():
+def test_zset_zrange_with_negative_indexes():
     r = fresh_redis()
     r.zadd('myzset', 0, 'myvalue1')
     r.zadd('myzset', 1, 'myvalue2')
@@ -352,3 +352,18 @@ def test_deleting_a_zset_should_not_impact_other_zsets():
 
     assert r.keys('*') == ['myzset2']
     assert r.zrange('myzset2', 0, 10) == ['test2']
+
+
+def test_order_of_zrange_with_negative_scores():
+    r = fresh_redis()
+
+    pairs = [
+        ('test1', -2.5),
+        ('test2', -1.1),
+        ('test3', 0.0),
+        ('test4', 1.2),
+        ('test5', 3.5),
+    ]
+    for member, score in pairs:
+        r.zadd('myzset', score, member)
+    assert r.zrange('myzset', 0, -1, withscores=True) == pairs

--- a/tests/unit/test_float_encoding.py
+++ b/tests/unit/test_float_encoding.py
@@ -1,0 +1,12 @@
+from dredis.utils import FLOAT_CODEC
+
+
+def test_encoding_keeps_natural_order():
+    floats = [1.5, -2.5, 0, 3.2, -2.0]
+    assert sorted(floats, key=FLOAT_CODEC.encode) == sorted(floats)
+
+
+def test_decoding_should_be_the_opposite_of_encoding():
+    floats = [1.5, -2.5, 0, 3.2, -2.0]
+    encoded_floats = map(FLOAT_CODEC.encode, floats)
+    assert map(FLOAT_CODEC.decode, encoded_floats) == floats


### PR DESCRIPTION
Before this commit, sorted set negative scores were stored after
all positive scores because of their binary representation.
For example:
```python
    >>> struct.pack('>d', -1)
    b'\xbf\xf0\x00\x00\x00\x00\x00\x00'
    >>> struct.pack('>d', +1)
    b'?\xf0\x00\x00\x00\x00\x00\x00'
    >>> struct.pack('>d', -1) < struct.pack('>d', +1)
    False
```
This commit introduces the FloatCodec class to encode/decode floats into bytes and vice-versa, preserving their numerical order.
For example, the following list is encoded to bytes while keeping and preserves its numerical order:
```python
    >>> floats = [1.5, -2.5, 3.2, 2.0]
    >>> sorted(floats, key=FloatCodec().encode)
    [-2.5, 1.5, 2.0, 3.2]
```

References:
* https://en.wikipedia.org/wiki/Floating-point_arithmetic#IEEE_754_design_rationale
* https://stackoverflow.com/a/43305015/565999
* https://stackoverflow.com/a/12933766/565999
* https://ananthakumaran.in/2018/08/17/order-preserving-serialization.html
* https://ananthakumaran.in/2018/08/17/order-preserving-serialization.html#float

**WARNING: This is a backward incompatible change and requires a major release!**


------

The bit flip is still magical. It seems to be a well-known way to encode floats/doubles but I couldn't find a reference implementation from the IEEE.