### PR TITLE
Refactor exception handling

### DIFF
--- a/dredis/commands.py
+++ b/dredis/commands.py
@@ -1,7 +1,7 @@
 import logging
 from functools import wraps
 
-from dredis.exceptions import AuthenticationRequiredError, CommandNotFound, DredisSyntaxError
+from dredis.exceptions import AuthenticationRequiredError, CommandNotFound, DredisSyntaxError, DredisError
 from dredis.utils import to_float
 
 logger = logging.getLogger(__name__)
@@ -425,6 +425,6 @@ def run_command(keyspace, cmd, args, readonly=False):
         if keyspace.requirepass and not keyspace.authenticated and cmd_fn != cmd_auth:
             raise AuthenticationRequiredError()
         if readonly and cmd_fn.flags & CMD_WRITE:
-            raise ValueError("Can't execute %r in readonly mode" % cmd)
+            raise DredisError("Can't execute %r in readonly mode" % cmd)
         else:
             return cmd_fn(keyspace, *str_args)

--- a/dredis/commands.py
+++ b/dredis/commands.py
@@ -1,7 +1,7 @@
 import logging
 from functools import wraps
 
-from dredis.exceptions import AuthenticationRequiredError
+from dredis.exceptions import AuthenticationRequiredError, CommandNotFound
 from dredis.utils import to_float
 
 logger = logging.getLogger(__name__)
@@ -413,10 +413,6 @@ def cmd_hincrby(keyspace, key, field, increment):
 @command('HGETALL', arity=2, flags=CMD_READONLY)
 def cmd_hgetall(keyspace, key):
     return keyspace.hgetall(key)
-
-
-class CommandNotFound(Exception):
-    """Exception to flag not found Redis command"""
 
 
 def run_command(keyspace, cmd, args, readonly=False):

--- a/dredis/exceptions.py
+++ b/dredis/exceptions.py
@@ -28,3 +28,9 @@ class BusyKeyError(DredisError):
 
     def __init__(self):
         self.msg = 'BUSYKEY Target key name already exists'
+
+
+class NoKeyError(DredisError):
+
+    def __init__(self):
+        self.msg = "NOKEY no such key"

--- a/dredis/exceptions.py
+++ b/dredis/exceptions.py
@@ -15,3 +15,10 @@ class AuthenticationRequiredError(DredisError):
 
 class CommandNotFound(DredisError):
     """Exception to flag not found Redis command"""
+
+
+class DredisSyntaxError(DredisError):
+    """Exception used to flag a bad command signature"""
+
+    def __init__(self, msg='syntax error'):
+        super(DredisSyntaxError, self).__init__(msg)

--- a/dredis/exceptions.py
+++ b/dredis/exceptions.py
@@ -11,3 +11,7 @@ class AuthenticationRequiredError(DredisError):
 
     def __init__(self):
         self.msg = 'NOAUTH Authentication required.'
+
+
+class CommandNotFound(DredisError):
+    """Exception to flag not found Redis command"""

--- a/dredis/exceptions.py
+++ b/dredis/exceptions.py
@@ -1,43 +1,54 @@
 class DredisError(Exception):
 
-    def __init__(self, msg):
-        self.msg = 'ERR %s' % msg
+    PREFIX = 'ERR'
+    DEFAULT_MSG = 'dredis error'
+
+    def __init__(self, msg=None):
+        self.msg = self.DEFAULT_MSG if msg is None else msg
 
     def __str__(self):
-        return self.msg
+        return self.error_msg
+
+    @property
+    def error_msg(self):
+        if self.PREFIX:
+            return '%s %s' % (self.PREFIX, self.msg)
+        else:
+            return self.msg
 
 
 class AuthenticationRequiredError(DredisError):
 
-    def __init__(self):
-        self.msg = 'NOAUTH Authentication required.'
+    PREFIX = 'NOAUTH'
+    DEFAULT_MSG = 'Authentication required.'
 
 
 class CommandNotFound(DredisError):
     """Exception to flag not found Redis command"""
 
+    DEFAULT_MSG = 'command not found'
+
 
 class DredisSyntaxError(DredisError):
     """Exception used to flag a bad command signature"""
 
-    def __init__(self, msg='syntax error'):
-        super(DredisSyntaxError, self).__init__(msg)
+    DEFAULT_MSG = 'syntax error'
 
 
 class BusyKeyError(DredisError):
 
-    def __init__(self):
-        self.msg = 'BUSYKEY Target key name already exists'
+    PREFIX = 'BUSYKEY'
+    DEFAULT_MSG = 'Target key name already exists'
 
 
 class NoKeyError(DredisError):
 
-    def __init__(self):
-        self.msg = "NOKEY no such key"
+    PREFIX = 'NOKEY'
+    DEFAULT_MSG = "no such key"
 
 
 class RedisScriptError(DredisError):
     """Indicate error from calls to redis.call()"""
 
-    def __init__(self, msg):
-        self.msg = msg  # Lua errors don't have the ERR prefix
+    PREFIX = ''  # Lua errors don't have the ERR prefix
+    DEFAULT_MSG = '@user_script: lua error'

--- a/dredis/exceptions.py
+++ b/dredis/exceptions.py
@@ -34,3 +34,10 @@ class NoKeyError(DredisError):
 
     def __init__(self):
         self.msg = "NOKEY no such key"
+
+
+class RedisScriptError(DredisError):
+    """Indicate error from calls to redis.call()"""
+
+    def __init__(self, msg):
+        self.msg = msg  # Lua errors don't have the ERR prefix

--- a/dredis/exceptions.py
+++ b/dredis/exceptions.py
@@ -22,3 +22,9 @@ class DredisSyntaxError(DredisError):
 
     def __init__(self, msg='syntax error'):
         super(DredisSyntaxError, self).__init__(msg)
+
+
+class BusyKeyError(DredisError):
+
+    def __init__(self):
+        self.msg = 'BUSYKEY Target key name already exists'

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -5,7 +5,7 @@ from io import BytesIO
 
 from dredis import rdb
 from dredis.db import DB_MANAGER, KEY_CODEC
-from dredis.exceptions import DredisError
+from dredis.exceptions import DredisError, BusyKeyError
 from dredis.lua import LuaRunner
 from dredis.utils import to_float
 
@@ -458,7 +458,7 @@ class Keyspace(object):
             if replace:
                 self.delete(key)
             else:
-                raise KeyError('BUSYKEY Target key name already exists')
+                raise BusyKeyError()
         rdb.verify_payload(payload)
         rdb.load_object(self, key, BytesIO(payload))
 

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -5,7 +5,7 @@ from io import BytesIO
 
 from dredis import rdb
 from dredis.db import DB_MANAGER, KEY_CODEC
-from dredis.exceptions import DredisError, BusyKeyError
+from dredis.exceptions import DredisError, BusyKeyError, NoKeyError
 from dredis.lua import LuaRunner
 from dredis.utils import to_float
 
@@ -470,7 +470,7 @@ class Keyspace(object):
             self.restore(new_name, ttl=0, payload=dump, replace=True)
             self.delete(old_name)
         else:
-            raise ValueError("no such key")
+            raise NoKeyError()
 
     def auth(self, password):
         if not self.requirepass:

--- a/dredis/lua.py
+++ b/dredis/lua.py
@@ -2,7 +2,8 @@ import json
 
 from lupa._lupa import LuaRuntime
 
-from dredis.commands import run_command, CommandNotFound, SimpleString
+from dredis.commands import run_command, SimpleString
+from dredis.exceptions import CommandNotFound
 
 
 class RedisScriptError(Exception):

--- a/dredis/lua.py
+++ b/dredis/lua.py
@@ -3,11 +3,7 @@ import json
 from lupa._lupa import LuaRuntime
 
 from dredis.commands import run_command, SimpleString
-from dredis.exceptions import CommandNotFound
-
-
-class RedisScriptError(Exception):
-    """Indicate error from calls to redis.call()"""
+from dredis.exceptions import CommandNotFound, RedisScriptError, DredisError
 
 
 class RedisLua(object):
@@ -21,7 +17,7 @@ class RedisLua(object):
             result = run_command(self._keyspace, cmd, args)
         except CommandNotFound:
             raise RedisScriptError('@user_script: Unknown Redis command called from Lua script')
-        except Exception as exc:
+        except DredisError as exc:
             raise RedisScriptError(str(exc))
         else:
             return self._convert_redis_types_to_lua_types(result)
@@ -97,7 +93,7 @@ class LuaRunner(object):
             """
             if isinstance(value, self._lua_table_type):
                 if 'err' in value:
-                    raise ValueError(value['err'])
+                    raise RedisScriptError(value['err'])
                 elif 'ok' in value:
                     return value['ok']
                 else:

--- a/dredis/lua.py
+++ b/dredis/lua.py
@@ -18,7 +18,7 @@ class RedisLua(object):
         except CommandNotFound:
             raise RedisScriptError('@user_script: Unknown Redis command called from Lua script')
         except DredisError as exc:
-            raise RedisScriptError(str(exc))
+            raise RedisScriptError(exc.msg)
         else:
             return self._convert_redis_types_to_lua_types(result)
 

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -59,7 +59,7 @@ def transform(obj):
         elif isinstance(elem, DredisError):
             result.append('-{}\r\n'.format(str(elem)))
         elif isinstance(elem, Exception):
-            result.append('-ERR {}\r\n'.format(str(elem)))
+            result.append('-INTERNALERROR {}\r\n'.format(str(elem)))
         else:
             assert False, 'couldnt catch a response for {} (type {})'.format(repr(elem), type(elem))
 

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -14,7 +14,7 @@ import sys
 from dredis import __version__
 from dredis import db, rdb
 from dredis.commands import run_command, SimpleString
-from dredis.exceptions import DredisError, RedisScriptError
+from dredis.exceptions import DredisError
 from dredis.keyspace import Keyspace
 from dredis.parser import Parser
 from dredis.path import Path
@@ -29,7 +29,7 @@ REQUIREPASS = None
 def execute_cmd(keyspace, send_fn, cmd, *args):
     try:
         result = run_command(keyspace, cmd, args, readonly=READONLY_SERVER)
-    except (DredisError, RedisScriptError) as exc:
+    except DredisError as exc:
         transmit(send_fn, exc)
     except Exception as exc:
         # no tests cover this part because it's meant for internal errors,

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -13,8 +13,8 @@ import sys
 
 from dredis import __version__
 from dredis import db, rdb
-from dredis.commands import run_command, SimpleString, CommandNotFound
-from dredis.exceptions import DredisError
+from dredis.commands import run_command, SimpleString
+from dredis.exceptions import DredisError, CommandNotFound
 from dredis.keyspace import Keyspace
 from dredis.lua import RedisScriptError
 from dredis.parser import Parser

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -14,9 +14,8 @@ import sys
 from dredis import __version__
 from dredis import db, rdb
 from dredis.commands import run_command, SimpleString
-from dredis.exceptions import DredisError, CommandNotFound
+from dredis.exceptions import DredisError, RedisScriptError
 from dredis.keyspace import Keyspace
-from dredis.lua import RedisScriptError
 from dredis.parser import Parser
 from dredis.path import Path
 
@@ -30,9 +29,7 @@ REQUIREPASS = None
 def execute_cmd(keyspace, send_fn, cmd, *args):
     try:
         result = run_command(keyspace, cmd, args, readonly=READONLY_SERVER)
-    # FIXME: these exceptions should all be custom,
-    #  otherwise it's hard to distinguish between expected and unexpected errors.
-    except (DredisError, SyntaxError, CommandNotFound, ValueError, RedisScriptError, KeyError) as exc:
+    except (DredisError, RedisScriptError) as exc:
         transmit(send_fn, exc)
     except Exception as exc:
         # no tests cover this part because it's meant for internal errors,

--- a/tests/integration/test_keys.py
+++ b/tests/integration/test_keys.py
@@ -138,7 +138,7 @@ def test_rename_when_key_doesnt_exist():
 
     with pytest.raises(redis.ResponseError) as exc:
         r.rename('notfound', 'newname')
-    assert str(exc.value) == 'no such key'
+    assert str(exc.value) == 'NOKEY no such key'
 
 
 def test_rename_when_new_key_already_exists():

--- a/tests/unit/test_eval.py
+++ b/tests/unit/test_eval.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dredis.keyspace import Keyspace
-from dredis.lua import RedisScriptError
+from dredis.exceptions import RedisScriptError
 
 
 def test_eval_with_error_call():
@@ -15,5 +15,5 @@ def test_eval_with_error_call():
 def test_eval_with_error_pcall():
     k = Keyspace()
 
-    with pytest.raises(ValueError, message='ERR Error running script: @user_script: Unknown Redis command called from Lua script'):
+    with pytest.raises(RedisScriptError, message='Error running script: @user_script: Unknown Redis command called from Lua script'):
         k.eval("""return redis.pcall('cmd_not_found')""", [], [])

--- a/tests/unit/test_lua.py
+++ b/tests/unit/test_lua.py
@@ -1,8 +1,9 @@
 import pytest
 
 from lupa._lupa import LuaRuntime
+
 from dredis.keyspace import Keyspace
-from dredis.lua import RedisScriptError
+from dredis.exceptions import RedisScriptError
 from dredis.lua import LuaRunner, RedisLua
 
 
@@ -17,12 +18,12 @@ def test_lua_return_redis_types_run():
 def test_lua_table_with_error_run():
     k = Keyspace()
     runner = LuaRunner(k)
-    lua_script_err = """return {err='This is a ValueError'}"""
+    lua_script_err = """return {err='This is an error'}"""
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(RedisScriptError) as e:
         runner.run(lua_script_err, [], [])
 
-    assert str(e.value) == 'This is a ValueError'
+    assert str(e.value) == 'This is an error'
 
 
 def test_lua_table_with_ok_run():

--- a/tests/unit/test_rdb.py
+++ b/tests/unit/test_rdb.py
@@ -6,6 +6,7 @@ import pytest
 
 import dredis
 from dredis import rdb, crc64
+from dredis.exceptions import DredisError
 from dredis.keyspace import Keyspace
 from tests.fixtures import reproduce_dump
 
@@ -40,17 +41,17 @@ def test_load_rdb_with_strings(keyspace):
 
 
 def test_load_invalid_rdb(keyspace):
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(DredisError) as exc:
         rdb_file = BytesIO('XREDIS0007')
         rdb.load_rdb(keyspace, rdb_file)
     assert str(exc).endswith('Wrong signature trying to load DB from file')
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(DredisError) as exc:
         rdb_file = BytesIO('REDIS000X')
         rdb.load_rdb(keyspace, rdb_file)
     assert str(exc).endswith("Can't handle RDB format version 000X")
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(DredisError) as exc:
         rdb_file = BytesIO('REDIS0011')
         rdb.load_rdb(keyspace, rdb_file)
     assert str(exc).endswith("Can't handle RDB format version 0011")

--- a/tests/unit/test_restore.py
+++ b/tests/unit/test_restore.py
@@ -4,6 +4,7 @@ from io import BytesIO
 import pytest
 
 from dredis import crc64, rdb
+from dredis.exceptions import BusyKeyError
 from dredis.keyspace import to_float_string
 from dredis.rdb import ObjectLoader
 
@@ -34,7 +35,7 @@ def test_should_throw_an_error_with_invalid_checksum(keyspace):
 
 def test_should_raise_an_error_when_key_exists_and_replace_is_false(keyspace):
     keyspace.set('test', 'testvalue')
-    with pytest.raises(KeyError) as exc:
+    with pytest.raises(BusyKeyError) as exc:
         keyspace.restore('test', ttl=0, payload='testvalue1', replace=False)
     assert 'BUSYKEY Target key name already exists' in str(exc)
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -33,4 +33,4 @@ def test_transform_nested_array():
 
 
 def test_transform_error():
-    assert transform(Exception('test')) == '-ERR test\r\n'
+    assert transform(Exception('test')) == '-INTERNALERROR test\r\n'


### PR DESCRIPTION
Before this PR, many stdlib exceptions were being used and it was hard to differentiate between real errors and dredis errors (for example, a ValueError could mean a bad data format or a bug when converting numbers to integer).

All exceptions now live in `exceptions.py` and inherit from `DredisError`.