### PR TITLE
Simplify keyspace to not convert floats to strings

### DIFF
--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -233,7 +233,7 @@ class Keyspace(object):
             db_value = KEY_CODEC.decode_zset_value(db_key)
             result.append(db_value)
             if with_scores:
-                result.append(to_float_string(db_score))
+                result.append(db_score)
 
         return result
 
@@ -241,11 +241,7 @@ class Keyspace(object):
         return int(self._db.get(KEY_CODEC.encode_zset(key), '0'))
 
     def zscore(self, key, member):
-        result = self._db.get(KEY_CODEC.encode_zset_value(key, member))
-        if result is None:
-            return result
-        else:
-            return to_float_string(result)
+        return self._db.get(KEY_CODEC.encode_zset_value(key, member))
 
     def zscan(self, key, cursor, match, count):
         members = []
@@ -325,7 +321,7 @@ class Keyspace(object):
                     db_value = KEY_CODEC.decode_zset_value(db_key)
                     result.append(db_value)
                     if withscores:
-                        result.append(to_float_string(db_score))
+                        result.append(db_score)
         return result
 
     def zcount(self, key, min_score, max_score):

--- a/tests/unit/test_dump_and_restore_fuzz.py
+++ b/tests/unit/test_dump_and_restore_fuzz.py
@@ -1,8 +1,6 @@
 import random
 import string
 
-from dredis.keyspace import to_float_string
-
 
 def _get_random_string():
     return ''.join(random.choice(string.printable) for _ in range(int(random.random() * MAX_LENGTH)))
@@ -47,7 +45,7 @@ def test_dump_and_restore_fuzzy_sorted_sets(keyspace):
     fuzzy_sorted_set = {}
     for score, value in zip(FUZZY_FLOATS, FUZZY_STRINGS):
         keyspace.zadd(key1, score=score, value=value)
-        fuzzy_sorted_set[value] = to_float_string(score)
+        fuzzy_sorted_set[value] = score
 
     keyspace.restore(key2, 0, keyspace.dump(key1), replace=True)
 

--- a/tests/unit/test_restore.py
+++ b/tests/unit/test_restore.py
@@ -5,7 +5,6 @@ import pytest
 
 from dredis import crc64, rdb
 from dredis.exceptions import BusyKeyError, DredisError
-from dredis.keyspace import to_float_string
 from dredis.rdb import ObjectLoader
 
 
@@ -87,8 +86,7 @@ def test_should_be_able_to_restore_sorted_sets(keyspace):
     # using a `dict` to avoid ordered comparision of `flat_pairs`
     flat_pairs_dict = {}
     for i in range(0, len(flat_pairs), 2):
-        # keyspace.zrange() returns scores as strings
-        flat_pairs_dict[flat_pairs[i]] = to_float_string(flat_pairs[i + 1])
+        flat_pairs_dict[flat_pairs[i]] = flat_pairs[i + 1]
     zrange = keyspace.zrange('zset2', 0, -1, with_scores=True)
     assert dict(zip(zrange[::2], zrange[1::2])) == flat_pairs_dict
 
@@ -185,7 +183,7 @@ def test_zset_as_ziplist(keyspace):
 
     assert keyspace.zrange('zset', 0, -1, with_scores=True) == [
         "test value",
-        "123",
+        123,
     ]
 
 


### PR DESCRIPTION
Commit ff3143bc21042f46f58a682dad800c862b7f1a37 added float support to `server.transform()` and we can now avoid using `to_float_string` in a few places.