### PR TITLE
Add support to HSCAN. Fix #46

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ services:
   - redis-server
 install: make setup
 env:
-  - TEST_SUITE=fulltests
+  - TEST_SUITE=fulltests BACKEND="--backend memory"
+  - TEST_SUITE=fulltests BACKEND="--backend lmdb"
+  - TEST_SUITE=fulltests BACKEND="--backend leveldb"
   - TEST_SUITE=fulltests-real-redis
 script: make $TEST_SUITE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Not released yet
 
+* Add support to HSCAN (https://github.com/Yipit/dredis/pull/47)
+
 ## 2.2.0
 
 * Add support to ZSCAN (https://github.com/Yipit/dredis/pull/43)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ export PYTHONPATH=.
 DEBUG ?= --debug
 FLUSHALL_ON_STARTUP ?= --flushall
 PORT ?= --port 6377
-TEST_OPTIONS = $(DEBUG) $(FLUSHALL_ON_STARTUP) $(PORT)
+BACKEND ?= --backend leveldb
+TEST_OPTIONS = $(DEBUG) $(FLUSHALL_ON_STARTUP) $(PORT) $(BACKEND)
 PID = dredis-test-server.pid
 REDIS_PID = redis-test-server.pid
 

--- a/dredis/commands.py
+++ b/dredis/commands.py
@@ -348,29 +348,8 @@ def cmd_zrangebyscore(keyspace, key, min_score, max_score, *args):
 
 @command('ZSCAN', arity=-3, flags=CMD_READONLY)
 def cmd_zscan(keyspace, key, cursor, *args):
-    match = None
-    count = 10
-    args = list(args)
-    try:
-        cursor = int(cursor)
-    except ValueError:
-        raise DredisError("invalid cursor")
-    while args:
-        arg = args.pop(0)
-        if len(args) < 1:
-            raise DredisSyntaxError()
-        else:
-            if arg.lower() == 'match':
-                match = args.pop(0)
-            elif arg.lower() == 'count':
-                try:
-                    count = int(args.pop(0))
-                except ValueError:
-                    raise DredisError("value is not an integer or out of range")
-            else:
-                raise DredisSyntaxError()
-    new_cursor, members = keyspace.zscan(key, cursor, match, count)
-    return [new_cursor, members]
+    count, cursor, match = _validate_scan_params(args, cursor)
+    return keyspace.zscan(key, cursor, match, count)
 
 
 def _validate_zset_score(score):
@@ -457,6 +436,37 @@ def cmd_hincrby(keyspace, key, field, increment):
 @command('HGETALL', arity=2, flags=CMD_READONLY)
 def cmd_hgetall(keyspace, key):
     return keyspace.hgetall(key)
+
+
+@command('HSCAN', arity=-3, flags=CMD_READONLY)
+def cmd_hscan(keyspace, key, cursor, *args):
+    count, cursor, match = _validate_scan_params(args, cursor)
+    return keyspace.hscan(key, cursor, match, count)
+
+
+def _validate_scan_params(args, cursor):
+    match = None
+    count = 10
+    args = list(args)
+    try:
+        cursor = int(cursor)
+    except ValueError:
+        raise DredisError("invalid cursor")
+    while args:
+        arg = args.pop(0)
+        if len(args) < 1:
+            raise DredisSyntaxError()
+        else:
+            if arg.lower() == 'match':
+                match = args.pop(0)
+            elif arg.lower() == 'count':
+                try:
+                    count = int(args.pop(0))
+                except ValueError:
+                    raise DredisError("value is not an integer or out of range")
+            else:
+                raise DredisSyntaxError()
+    return count, cursor, match
 
 
 def run_command(keyspace, cmd, args, readonly=False):

--- a/dredis/commands.py
+++ b/dredis/commands.py
@@ -348,7 +348,7 @@ def cmd_zrangebyscore(keyspace, key, min_score, max_score, *args):
 
 @command('ZSCAN', arity=-3, flags=CMD_READONLY)
 def cmd_zscan(keyspace, key, cursor, *args):
-    count, cursor, match = _validate_scan_params(args, cursor)
+    cursor, count, match = _validate_scan_params(args, cursor)
     return keyspace.zscan(key, cursor, match, count)
 
 
@@ -440,7 +440,7 @@ def cmd_hgetall(keyspace, key):
 
 @command('HSCAN', arity=-3, flags=CMD_READONLY)
 def cmd_hscan(keyspace, key, cursor, *args):
-    count, cursor, match = _validate_scan_params(args, cursor)
+    cursor, count, match = _validate_scan_params(args, cursor)
     return keyspace.hscan(key, cursor, match, count)
 
 
@@ -466,7 +466,7 @@ def _validate_scan_params(args, cursor):
                     raise DredisError("value is not an integer or out of range")
             else:
                 raise DredisSyntaxError()
-    return count, cursor, match
+    return cursor, count, match
 
 
 def run_command(keyspace, cmd, args, readonly=False):

--- a/dredis/db.py
+++ b/dredis/db.py
@@ -159,13 +159,13 @@ class LMDBBackend(object):
     def close(self):
         self._env.close()
 
-    def iterator(self, prefix='', start='', include_value=True):
+    def iterator(self, prefix=None, start=None, include_value=True):
         with self._env.begin() as t:
             c = t.cursor()
-            if start and not c.set_range(start):
+            if start is not None and not c.set_range(start):
                 return
             for k, v in c:
-                if not k.startswith(prefix):
+                if prefix is not None and not k.startswith(prefix):
                     return
                 if include_value:
                     yield k, v
@@ -212,11 +212,11 @@ class MemoryBackend(object):
         if exc_type is None:
             return True
 
-    def iterator(self, prefix='', start='', include_value=True):
+    def iterator(self, prefix=None, start=None, include_value=True):
         for k, v in self:
-            if k < start:
+            if start is not None and k < start:
                 continue
-            if not k.startswith(prefix):
+            if prefix is not None and not k.startswith(prefix):
                 continue
             if include_value:
                 yield k, v

--- a/dredis/db.py
+++ b/dredis/db.py
@@ -160,6 +160,10 @@ class LMDBBackend(object):
         self._env.close()
 
     def iterator(self, prefix=None, start=None, include_value=True):
+        # LMDB doesn't have native prefix support, we must call `set_range()` to start it at the proper position,
+        # otherwise it'd require extra iterations to filter by prefix.
+        if start is None:
+            start = prefix
         with self._env.begin() as t:
             c = t.cursor()
             if start is not None and not c.set_range(start):

--- a/dredis/db.py
+++ b/dredis/db.py
@@ -159,10 +159,10 @@ class LMDBBackend(object):
     def close(self):
         self._env.close()
 
-    def iterator(self, prefix='', include_value=True):
+    def iterator(self, prefix='', start='', include_value=True):
         with self._env.begin() as t:
             c = t.cursor()
-            if prefix and not c.set_range(prefix):
+            if start and not c.set_range(start):
                 return
             for k, v in c:
                 if not k.startswith(prefix):
@@ -212,8 +212,10 @@ class MemoryBackend(object):
         if exc_type is None:
             return True
 
-    def iterator(self, prefix='', include_value=True):
+    def iterator(self, prefix='', start='', include_value=True):
         for k, v in self:
+            if k < start:
+                continue
             if not k.startswith(prefix):
                 continue
             if include_value:

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -49,7 +49,7 @@ class Cursors(object):
         return (db, key, cursor_id)
 
 
-CURSOR_MAX_SIZE = 1024
+CURSOR_MAX_SIZE = 8 * 1024
 ZSET_CURSORS = Cursors(CURSOR_MAX_SIZE)
 HASH_CURSORS = Cursors(CURSOR_MAX_SIZE)
 

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -184,8 +184,13 @@ class Keyspace(object):
             for db_key, _ in self._get_db_iterator(KEY_CODEC.get_min_zset_value(key)):
                 batch.delete(db_key)
 
-    def _get_db_iterator(self, key_prefix):
-        for db_key, db_value in self._db.iterator(prefix=key_prefix):
+    def _get_db_iterator(self, key_prefix=None, start=None):
+        options = {}
+        if key_prefix:
+            options['prefix'] = key_prefix
+        if start:
+            options['start'] = start
+        for db_key, db_value in self._db.iterator(**options):
             yield db_key, db_value
 
     def zadd(self, key, score, value):
@@ -253,12 +258,11 @@ class Keyspace(object):
                 db_key_from_cursor = ZSET_CURSORS.get(self._current_db, key, cursor)
             except KeyError:
                 return [new_cursor, members]
-
-        for i, (db_key, _) in enumerate(self._get_db_iterator(db_key_from_cursor)):
+        for i, (db_key, _) in enumerate(self._get_db_iterator(start=db_key_from_cursor)):
             db_score = KEY_CODEC.decode_zset_score(db_key)
             db_value = KEY_CODEC.decode_zset_value(db_key)
             # store the next element at the cursor
-            if i > count:
+            if i == count:
                 new_cursor = ZSET_CURSORS.add(self._current_db, key, db_key)
                 break
             if match is None or fnmatch.fnmatch(db_value, match):

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -186,12 +186,7 @@ class Keyspace(object):
                 batch.delete(db_key)
 
     def _get_db_iterator(self, key_prefix=None, start=None):
-        options = {}
-        if key_prefix:
-            options['prefix'] = key_prefix
-        if start:
-            options['start'] = start
-        for db_key, db_value in self._db.iterator(**options):
+        for db_key, db_value in self._db.iterator(prefix=key_prefix, start=start):
             yield db_key, db_value
 
     def zadd(self, key, score, value):

--- a/tests/integration/test_hash.py
+++ b/tests/integration/test_hash.py
@@ -4,6 +4,10 @@ import redis
 from tests.helpers import fresh_redis
 
 
+HASH_MAX_ZIPLIST_ENTRIES = 512  # redis uses a ziplist for hashes of 512 or fewer entries
+HASH_MIN_HASHTABLE_ENTRIES = HASH_MAX_ZIPLIST_ENTRIES + 100
+
+
 def test_hset_and_hget():
     r = fresh_redis()
 
@@ -131,9 +135,9 @@ def test_hscan_with_all_elements_returned():
 def test_hscan_with_a_subset_of_elements_returned():
     r = fresh_redis()
 
-    # adding 200 elements to prevent real Redis from using a compact data structure
+    # adding lots of elements to prevent real Redis from using a compact data structure
     # and returning all elements regardless of `COUNT`
-    pairs = {'key{}'.format(i): 'value{}'.format(i) for i in range(200)}
+    pairs = {'key{}'.format(i): 'value{}'.format(i) for i in range(HASH_MIN_HASHTABLE_ENTRIES)}
     for key, value in pairs.items():
         r.hset('myhash', key, value)
 
@@ -159,9 +163,9 @@ def test_hscan_with_a_subset_of_matching_elements_returned():
         'a-test4': 'd',
         'b-test5': 'e',
     }
-    # adding 200 elements to prevent real Redis from using a compact data structure
+    # adding lots of elements to prevent real Redis from using a compact data structure
     # and returning all elements regardless of `COUNT`
-    pairs.update({'c-test{}'.format(i): 'c-value-{}'.format(i) for i in range(6, 200)})
+    pairs.update({'c-test{}'.format(i): 'c-value-{}'.format(i) for i in range(6, HASH_MIN_HASHTABLE_ENTRIES)})
     for key, value in pairs.items():
         r.hset('myhash', key, value)
 

--- a/tests/integration/test_zset.py
+++ b/tests/integration/test_zset.py
@@ -411,6 +411,15 @@ def test_zscan_with_a_subset_of_elements_returned():
     for e in elems2:
         assert e in pairs
 
+    found_elems = []
+    cursor3 = 0
+    while True:
+        cursor3, elems3 = r.zscan('myzset', cursor3, count=1)
+        found_elems.extend(elems3)
+        if cursor3 == 0:
+            break
+    assert sorted(pairs) == sorted(found_elems)
+
 
 def test_zscan_with_a_subset_of_matching_elements_returned():
     r = fresh_redis()

--- a/tests/integration/test_zset.py
+++ b/tests/integration/test_zset.py
@@ -5,6 +5,9 @@ import redis
 
 from tests.helpers import fresh_redis
 
+ZSET_MAX_ZIPLIST_ENTRIES = 128  # redis uses a ziplist for zsets of 128 or fewer entries
+ZSET_MIN_HASHTABLE_ENTRIES = ZSET_MAX_ZIPLIST_ENTRIES + 100
+
 
 def test_zset_zadd_and_zcard():
     r = fresh_redis()
@@ -393,9 +396,9 @@ def test_zscan_with_all_elements_returned():
 def test_zscan_with_a_subset_of_elements_returned():
     r = fresh_redis()
 
-    # adding 200 elements to prevent real Redis from using a compact data structure
+    # adding lots of elements to prevent real Redis from using a compact data structure
     # and returning all elements regardless of `COUNT`
-    pairs = [('test{}'.format(i), i) for i in range(200)]
+    pairs = [('test{}'.format(i), i) for i in range(ZSET_MIN_HASHTABLE_ENTRIES)]
 
     random.shuffle(pairs)
     for member, score in pairs:
@@ -431,9 +434,9 @@ def test_zscan_with_a_subset_of_matching_elements_returned():
         ('a-test4', 4),
         ('b-test5', 5),
     ]
-    # adding 200 elements to prevent real Redis from using a compact data structure
+    # adding lots of elements to prevent real Redis from using a compact data structure
     # and returning all elements regardless of `COUNT`
-    pairs.extend([('c-test{}'.format(i), i) for i in range(6, 200)])
+    pairs.extend([('c-test{}'.format(i), i) for i in range(6, ZSET_MIN_HASHTABLE_ENTRIES)])
     random.shuffle(pairs)
     for member, score in pairs:
         r.zadd('myzset', score, member)


### PR DESCRIPTION
This PR adds the new command `HSCAN` and fixes a bug with `ZSCAN` and start keys.

The size of the cursors was bumped to `8 * 1024` because 1024 was not a lot of cursors and 8x that isn't a lot of memory space.