### PR TITLE
Add support for CONFIG GET and CONFIG SET

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ fulltests:
 	bash -c "trap 'make stop-testserver' EXIT; make start-testserver DEBUG=''; make test"
 
 fulltests-real-redis:
-	bash -c "trap 'make stop-redistestserver' EXIT; make start-redistestserver; make test"
+	bash -c "trap 'make stop-redistestserver' EXIT; make start-redistestserver; make test REALREDIS=1"
 
 test: unit integration lint
 

--- a/dredis/commands.py
+++ b/dredis/commands.py
@@ -1,6 +1,7 @@
 import logging
 from functools import wraps
 
+from dredis import config
 from dredis.exceptions import AuthenticationRequiredError, CommandNotFound, DredisSyntaxError, DredisError
 from dredis.utils import to_float
 
@@ -92,6 +93,25 @@ def cmd_dbsize(keyspace):
 def cmd_save(keyspace):
     keyspace.save()
     return SimpleString('OK')
+
+
+@command('CONFIG', arity=-2, flags=CMD_WRITE)
+def cmd_config(keyspace, action, *params):
+    if action.lower() == 'help':
+        # copied from
+        # https://github.com/antirez/redis/blob/cb51bb4320d2240001e8fc4a522d59fb28259703/src/config.c#L2244-L2245
+        help = [
+            "GET <pattern> -- Return parameters matching the glob-like <pattern> and their values.",
+            "SET <parameter> <value> -- Set parameter to value.",
+        ]
+        return help
+    elif action.lower() == 'get' and len(params) == 1:
+        return config.get_all(params[0])
+    elif action.lower() == 'set' and len(params) == 2:
+        config.set(params[0], params[1])
+        return SimpleString('OK')
+    else:
+        raise DredisError("Unknown subcommand or wrong number of arguments for '{}'. Try CONFIG HELP.".format(action))
 
 
 """

--- a/dredis/commands.py
+++ b/dredis/commands.py
@@ -497,9 +497,9 @@ def run_command(keyspace, cmd, args):
         raise CommandNotFound("unknown command '{}'".format(cmd))
     else:
         cmd_fn = REDIS_COMMANDS[cmd.upper()]
-        if config.get('requirepass') != '' and not keyspace.authenticated and cmd_fn != cmd_auth:
+        if config.get('requirepass') != config.EMPTY and not keyspace.authenticated and cmd_fn != cmd_auth:
             raise AuthenticationRequiredError()
-        if config.get('readonly') == 'true' and cmd_fn.flags & CMD_WRITE:
+        if config.get('readonly') == config.TRUE and cmd_fn.flags & CMD_WRITE:
             raise DredisError("Can't execute %r in readonly mode" % cmd)
         else:
             return cmd_fn(keyspace, *str_args)

--- a/dredis/commands.py
+++ b/dredis/commands.py
@@ -489,7 +489,7 @@ def _validate_scan_params(args, cursor):
     return cursor, count, match
 
 
-def run_command(keyspace, cmd, args, readonly=False):
+def run_command(keyspace, cmd, args):
     logger.debug('[run_command] cmd={}, args={}'.format(repr(cmd), repr(args)))
 
     str_args = map(str, args)
@@ -499,7 +499,7 @@ def run_command(keyspace, cmd, args, readonly=False):
         cmd_fn = REDIS_COMMANDS[cmd.upper()]
         if keyspace.requirepass and not keyspace.authenticated and cmd_fn != cmd_auth:
             raise AuthenticationRequiredError()
-        if readonly and cmd_fn.flags & CMD_WRITE:
+        if config.get('readonly') == 'true' and cmd_fn.flags & CMD_WRITE:
             raise DredisError("Can't execute %r in readonly mode" % cmd)
         else:
             return cmd_fn(keyspace, *str_args)

--- a/dredis/commands.py
+++ b/dredis/commands.py
@@ -497,7 +497,7 @@ def run_command(keyspace, cmd, args):
         raise CommandNotFound("unknown command '{}'".format(cmd))
     else:
         cmd_fn = REDIS_COMMANDS[cmd.upper()]
-        if keyspace.requirepass and not keyspace.authenticated and cmd_fn != cmd_auth:
+        if config.get('requirepass') != '' and not keyspace.authenticated and cmd_fn != cmd_auth:
             raise AuthenticationRequiredError()
         if config.get('readonly') == 'true' and cmd_fn.flags & CMD_WRITE:
             raise DredisError("Can't execute %r in readonly mode" % cmd)

--- a/dredis/config.py
+++ b/dredis/config.py
@@ -1,0 +1,31 @@
+import fnmatch
+
+from dredis.exceptions import DredisError
+
+
+_SERVER_CONFIG = {
+    'debug': 'false',
+    'readonly': 'false',
+    'requirepass': '',
+}
+
+
+def get_all(pattern):
+    result = []
+    for option, value in sorted(_SERVER_CONFIG.items()):
+        if not fnmatch.fnmatch(option, pattern):
+            continue
+        result.append(option)
+        result.append(value)
+    return result
+
+
+def set(option, value):
+    if option in _SERVER_CONFIG:
+        _SERVER_CONFIG[option] = value
+    else:
+        raise DredisError('Unsupported CONFIG parameter: {}'.format(option))
+
+
+def get(option):
+    return _SERVER_CONFIG[option]

--- a/dredis/config.py
+++ b/dredis/config.py
@@ -1,6 +1,8 @@
 import fnmatch
+import logging
 
 from dredis.exceptions import DredisError
+from dredis.utils import setup_logging
 
 TRUE = 'true'
 FALSE = 'false'
@@ -25,6 +27,14 @@ def get_all(pattern):
 
 def set(option, value):
     if option in _SERVER_CONFIG:
+        if option == 'debug':
+            value = _validate_bool(option, value)
+            if value == TRUE:
+                setup_logging(logging.DEBUG)
+            else:
+                setup_logging(logging.INFO)
+        elif option == 'readonly':
+            value = _validate_bool(option, value)
         _SERVER_CONFIG[option] = value
     else:
         raise DredisError('Unsupported CONFIG parameter: {}'.format(option))
@@ -32,3 +42,9 @@ def set(option, value):
 
 def get(option):
     return _SERVER_CONFIG[option]
+
+
+def _validate_bool(option, value):
+    if value.lower() not in (TRUE, FALSE):
+        raise DredisError("Invalid argument '{}' for CONFIG SET '{}'".format(value, option))
+    return value.lower()

--- a/dredis/config.py
+++ b/dredis/config.py
@@ -2,11 +2,14 @@ import fnmatch
 
 from dredis.exceptions import DredisError
 
+TRUE = 'true'
+FALSE = 'false'
+EMPTY = ''
 
 _SERVER_CONFIG = {
-    'debug': 'false',
-    'readonly': 'false',
-    'requirepass': '',
+    'debug': FALSE,
+    'readonly': FALSE,
+    'requirepass': EMPTY,
 }
 
 

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -61,7 +61,7 @@ class Keyspace(object):
         self._current_db = DEFAULT_REDIS_DB
         self._set_db(self._current_db)
         self._password = password
-        self.requirepass = password is not None
+        self.requirepass = password not in ('', None)
         self.authenticated = False
 
     def _set_db(self, db):

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -545,7 +545,7 @@ class Keyspace(object):
             raise NoKeyError()
 
     def auth(self, password):
-        if config.get('requirepass') == '':
+        if config.get('requirepass') == config.EMPTY:
             raise DredisError("client sent AUTH, but no password is set")
         if password != config.get('requirepass'):
             self.authenticated = False

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -4,7 +4,7 @@ import fnmatch
 import time
 from io import BytesIO
 
-from dredis import rdb
+from dredis import rdb, config
 from dredis.db import DB_MANAGER, KEY_CODEC, DEFAULT_REDIS_DB
 from dredis.exceptions import DredisError, BusyKeyError, NoKeyError
 from dredis.lua import LuaRunner
@@ -56,12 +56,10 @@ HASH_CURSORS = Cursors(CURSOR_MAX_SIZE)
 
 class Keyspace(object):
 
-    def __init__(self, password=None):
+    def __init__(self):
         self._lua_runner = LuaRunner(self)
         self._current_db = DEFAULT_REDIS_DB
         self._set_db(self._current_db)
-        self._password = password
-        self.requirepass = password not in ('', None)
         self.authenticated = False
 
     def _set_db(self, db):
@@ -547,9 +545,9 @@ class Keyspace(object):
             raise NoKeyError()
 
     def auth(self, password):
-        if not self.requirepass:
+        if config.get('requirepass') == '':
             raise DredisError("client sent AUTH, but no password is set")
-        if self._password != password:
+        if password != config.get('requirepass'):
             self.authenticated = False
             raise DredisError("invalid password")
         else:

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -77,7 +77,7 @@ class CommandHandler(asyncore.dispatcher):
     def __init__(self, *args, **kwargs):
         asyncore.dispatcher.__init__(self, *args, **kwargs)
         self._parser = Parser(self.recv)  # contains client message buffer
-        self.keyspace = Keyspace(password=config.get('requirepass'))
+        self.keyspace = Keyspace()
 
     def handle_read(self):
         try:

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -26,7 +26,7 @@ ROOT_DIR = None  # defined by `main()`
 
 def execute_cmd(keyspace, send_fn, cmd, *args):
     try:
-        result = run_command(keyspace, cmd, args, readonly=config.get('readonly') == 'true')
+        result = run_command(keyspace, cmd, args)
     except DredisError as exc:
         transmit(send_fn, exc)
     except Exception as exc:

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -122,14 +122,6 @@ class RedisServer(asyncore.dispatcher):
             CommandHandler(sock)
 
 
-def setup_logging(level):
-    logger.setLevel(level)
-    formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(message)s')
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-
-
 def main():
     parser = argparse.ArgumentParser(version=__version__)
     parser.add_argument('--host', default='127.0.0.1', help='server host (defaults to %(default)s)')
@@ -159,9 +151,6 @@ def main():
 
     if args.debug:
         config.set('debug', 'true')
-        setup_logging(logging.DEBUG)
-    else:
-        setup_logging(logging.INFO)
 
     if args.readonly:
         config.set('readonly', 'true')

--- a/dredis/utils.py
+++ b/dredis/utils.py
@@ -1,4 +1,6 @@
+import logging
 import struct
+import sys
 
 
 def to_float(s):
@@ -54,3 +56,12 @@ class FloatCodec(object):
 
 
 FLOAT_CODEC = FloatCodec()
+
+
+def setup_logging(level):
+    logger = logging.getLogger('dredis')
+    logger.setLevel(level)
+    formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(message)s')
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -1,6 +1,9 @@
 import glob
 import os.path
 
+import pytest
+import redis
+
 from tests.helpers import fresh_redis
 
 
@@ -57,3 +60,60 @@ def test_save_creates_an_rdb_file():
     r.set('test', 'value')
     assert r.save()
     assert len(set(glob.glob(os.path.join(root_dir, 'dump*.rdb'))) - rdb_files_before) == 1
+
+
+def test_config_help():
+    r = fresh_redis()
+    result = r.execute_command('CONFIG', 'HELP')
+
+    # assert strings individually because redis has more help lines than dredis
+    assert "GET <pattern> -- Return parameters matching the glob-like <pattern> and their values." in result
+    assert "SET <parameter> <value> -- Set parameter to value." in result
+
+
+def test_config_get_with_unknown_config():
+    r = fresh_redis()
+
+    assert r.config_get('foo') == {}
+
+
+def test_config_get_with_wrong_number_of_arguments():
+    r = fresh_redis()
+
+    with pytest.raises(redis.ResponseError) as exc:
+        r.execute_command('CONFIG', 'GET', 'foo', 'bar', 'baz')
+
+    assert str(exc.value) == "Unknown subcommand or wrong number of arguments for 'GET'. Try CONFIG HELP."
+
+
+def test_config_set_with_unknown_config():
+    r = fresh_redis()
+
+    with pytest.raises(redis.ResponseError) as exc:
+        r.config_set('foo', 'bar')
+
+    assert str(exc.value) == "Unsupported CONFIG parameter: foo"
+
+
+@pytest.mark.skipif(os.getenv('REALREDIS') == '1', reason="these options only exist in dredis")
+def test_config_get():
+    r = fresh_redis()
+
+    assert sorted(r.config_get('*').keys()) == sorted(['debug', 'readonly', 'requirepass'])
+    assert r.config_get('*deb*').keys() == ['debug']
+
+
+@pytest.mark.skipif(os.getenv('REALREDIS') == '1', reason="these options only exist in dredis")
+def test_config_set():
+    r = fresh_redis()
+    original_value = r.config_get('debug')['debug']
+
+    try:
+        assert r.config_set('debug', 'false')
+        assert r.config_get('debug') == {'debug': 'false'}
+
+        assert r.config_set('debug', 'true')
+        assert r.config_get('debug') == {'debug': 'true'}
+    finally:
+        # undo it to not affect other tests
+        assert r.config_set('debug', original_value)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from dredis import config
 from dredis.db import DB_MANAGER
 from dredis.keyspace import Keyspace
 
@@ -7,4 +8,7 @@ from dredis.keyspace import Keyspace
 @pytest.fixture
 def keyspace():
     DB_MANAGER.setup_dbs('', backend='memory', backend_options={})
-    return Keyspace()
+    original_configs = config.get_all('*')
+    yield Keyspace()
+    for option, value in zip(original_configs[0::2], original_configs[1::2]):
+        config.set(option, value)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,3 +1,4 @@
+from dredis import config
 from dredis.server import transmit, transform
 import mock
 
@@ -34,3 +35,17 @@ def test_transform_nested_array():
 
 def test_transform_error():
     assert transform(Exception('test')) == '-INTERNALERROR test\r\n'
+
+
+def test_config():
+    original_value = config.get('debug')
+    try:
+        # change config
+        config.set('debug', 'false')
+        assert config.get('debug') is 'false'
+
+        config.set('debug', 'true')
+        assert config.get('debug') is 'true'
+    finally:
+        # undo it to not affect other tests
+        config.set('debug', original_value)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -42,10 +42,10 @@ def test_config():
     try:
         # change config
         config.set('debug', 'false')
-        assert config.get('debug') is 'false'
+        assert config.get('debug') == 'false'
 
         config.set('debug', 'true')
-        assert config.get('debug') is 'true'
+        assert config.get('debug') == 'true'
     finally:
         # undo it to not affect other tests
         config.set('debug', original_value)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,4 +1,3 @@
-from dredis import config
 from dredis.server import transmit, transform
 import mock
 
@@ -35,17 +34,3 @@ def test_transform_nested_array():
 
 def test_transform_error():
     assert transform(Exception('test')) == '-INTERNALERROR test\r\n'
-
-
-def test_config():
-    original_value = config.get('debug')
-    try:
-        # change config
-        config.set('debug', 'false')
-        assert config.get('debug') == 'false'
-
-        config.set('debug', 'true')
-        assert config.get('debug') == 'true'
-    finally:
-        # undo it to not affect other tests
-        config.set('debug', original_value)


### PR DESCRIPTION
This will enable a dynamic change of some options, such as `debug`. This will be useful when debugging slowdowns temporarily without having to restart the dredis server.