### PR TITLE
Optimization/faster parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Not released yet
 
+* Improve parser performance significantly for large commands (https://github.com/Yipit/dredis/pull/57)
+
 ## 2.5.2
 
 * Fix bug with big replies and `socket.send` (https://github.com/Yipit/dredis/pull/56)

--- a/dredis/parser.py
+++ b/dredis/parser.py
@@ -22,7 +22,7 @@ class Parser(object):
         self._buffer.extend(data)
 
     def _read(self, n_bytes):
-        if len(self._buffer[self._buffer_pos:]) < n_bytes:
+        if len(self._buffer[self._buffer_pos:]) < n_bytes + len(self.CRLF):
             raise StopIteration()
         result = self._buffer[self._buffer_pos:][:n_bytes]
         # FIXME: ensure self.CRLF is next

--- a/dredis/parser.py
+++ b/dredis/parser.py
@@ -61,6 +61,7 @@ class Parser(object):
                 instructions = self._readline()
                 self._trim_buffer()
                 yield str(instructions[1:].strip()).split()
+                self.reset()
 
     def _trim_buffer(self):
         self._buffer = self._buffer[self._buffer_pos:]

--- a/tests-performance/test_parsing.py
+++ b/tests-performance/test_parsing.py
@@ -1,0 +1,28 @@
+"""
+The following results should serve as reference
+------
+
+Results from 2020-01-09 on @htlbra's Macbook and LARGE_NUMBER = 50 * 1024 * 1024
+
+commit 63abbfd5df83eb5f0fa705487afc64f660cee82b:
+large SET time = 6.34038s
+
+commit a33e223ccfe413064b8656cee629ebbaa73f0dce:
+large SET time = 0.89820s
+"""
+
+import time
+
+from tests.helpers import fresh_redis
+
+
+PROFILE_PORT = 6376
+LARGE_NUMBER = 50 * 1024 * 1024  # 50MiB
+
+
+def test_very_large_command_to_parse():
+    r = fresh_redis(port=PROFILE_PORT)
+    before = time.time()
+    assert r.set("test", 'x' * LARGE_NUMBER)
+    after = time.time()
+    print '\nlarge SET time = {:.5f}s'.format(after - before)

--- a/tests/unit/test_redis_protocol.py
+++ b/tests/unit/test_redis_protocol.py
@@ -98,3 +98,12 @@ def test_missing_crlf_after_string():
 
     responses.append("\r\n")
     assert next(p.get_instructions()) == ['PING']
+
+
+def test_mixing_simple_messages_with_bulk_messages():
+    def read(bufsize):
+        return "+SIMPLE\r\n*1\r\n$4\r\nBULK\r\n+SIMPLE\r\n*1\r\n$4\r\nBULK\r\n"
+
+    p = Parser(read)
+
+    assert list(p.get_instructions()) == [['SIMPLE'], ['BULK'], ['SIMPLE'], ['BULK']]

--- a/tests/unit/test_redis_protocol.py
+++ b/tests/unit/test_redis_protocol.py
@@ -83,3 +83,18 @@ def test_parser_should_work_with_chunks_sent_separately():
 
     responses.append("G\r\n")
     assert next(p.get_instructions()) == ['PING']
+
+
+def test_missing_crlf_after_string():
+    responses = ["*1\r\n$4\r\nPING"]
+
+    def read(bufsize):
+        return responses.pop(0)
+
+    p = Parser(read)
+
+    with pytest.raises(StopIteration):
+        next(p.get_instructions())
+
+    responses.append("\r\n")
+    assert next(p.get_instructions()) == ['PING']


### PR DESCRIPTION
From https://github.com/Yipit/dredis/commit/2deb63f9956353a81ae34d637d5c457b63eae94e:
> There was too much re-parsing when dealing with large inputs that required multiple reads from the network.
> @jimjshields found this when sending about 10MB of data to dredis (it was hanging for a long time). That was hanging dredis because it was re-parsing the partial input every time there was new data.
> For example, if a client sent the following sequence of commands to parse:
> 1. "*1\r\n"
> 2. "$4\r\n"
> 3. "PING\r\n"
>
> After receiving payload #1, dredis would append it to a buffer and parse the buffer ("*1\r\n"). It is incomplete, so it moves on.
> After receiving payload #2, dredis would append it to a buffer and parse the buffer (now the buffer is "*1\r\n$4\r\n"). It is incomplete, so it moves on.
> After receiving payload #3, dredis would append it to a buffer and parse the buffer (nw the buffer is "*1\r\n$4\r\nPING\r\n"). It is finally complete, so it executes the command PING.
> If you follow this approach for a command with 50,000 elements, it would re-parse all elements until it reaches the final 50,000th element. A much better approach would be to save every parsed element and wait until the last element to execute the command, but never re-parse valid data.
>
> This commit changes the parser to never re-parse valid data. Using the previous example with the current implementation, after each new payload, dredis will only that and never re-parse the previous valid payloads.

---

This is heavily inspired by the Redis implementation: https://github.com/antirez/redis/blob/77de5c2b717bb24649f4bc448e3326b1d1218207/src/networking.c#L1122-L1249