### PR TITLE
Add asynchronous deletion and faster rename

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+.git
 *.pyc
 .idea/
 .pytest_cache/
+dredis-data*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Not released yet
 
+* Change zset, set, and hash implementation to use pointers to allow asynchronous deletion
+* Add a key garbage collector as a background thread to delete keys marked for deletion
+
 ## 2.5.3
 
 * Improve parser performance significantly for large commands (https://github.com/Yipit/dredis/pull/57)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ usage: dredis [-h] [-v] [--host HOST] [--port PORT] [--dir DIR]
               [--backend {lmdb,leveldb,memory}]
               [--backend-option BACKEND_OPTION] [--rdb RDB] [--debug]
               [--flushall] [--readonly]
+              [--gc-interval GC_INTERVAL] [--gc-batch-size GC_BATCH_SIZE]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -50,6 +51,10 @@ optional arguments:
   --debug               enable debug logs
   --flushall            run FLUSHALL on startup
   --readonly            accept read-only commands
+  --gc-interval GC_INTERVAL
+                        key gc interval in milliseconds (defaults to 500)
+  --gc-batch-size GC_BATCH_SIZE
+                        key gc batch size (defaults to 10000)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ dredis --help
 usage: dredis [-h] [-v] [--host HOST] [--port PORT] [--dir DIR]
               [--backend {lmdb,leveldb,memory}]
               [--backend-option BACKEND_OPTION] [--rdb RDB] [--debug]
-              [--flushall] [--readonly]
+              [--flushall] [--readonly] [--requirepass REQUIREPASS]
               [--gc-interval GC_INTERVAL] [--gc-batch-size GC_BATCH_SIZE]
 
 optional arguments:
@@ -51,6 +51,9 @@ optional arguments:
   --debug               enable debug logs
   --flushall            run FLUSHALL on startup
   --readonly            accept read-only commands
+  --requirepass REQUIREPASS
+                        require clients to issue AUTH <password> before
+                        processing any other commands
   --gc-interval GC_INTERVAL
                         key gc interval in milliseconds (defaults to 500)
   --gc-batch-size GC_BATCH_SIZE

--- a/README.md
+++ b/README.md
@@ -67,7 +67,15 @@ Running dredis with Docker locally (port 6377 on the host):
 $ docker-compose up
 ```
 
+## Asynchronous Deletions (Key Garbage Collection)
 
+This is a new and experimental feature that was necessary at Yipit to offload dredis on `RENAME` and `DEL` operations.
+When a sorted set, hash, or set is stored using any of the backends, dredis creates a few keys in the backend for each element of those collections.
+With this new feature, on `RENAME` and `DELETE`, only the key holding the key ID/pointer is replaced/deleted.
+There's a background thread that periodically deletes those related keys from the storage backend (you can tweak the GC options via `--gc-interval` and `--gc-batch-size`).
+Despite the asynchronous deletions, the deletion operation still ensures strong consistency because of the use of key IDs/pointers.
+
+If you don't want this experimental feature, you need to go back to DRedis 2.5.3.
 
 ## Backends
 

--- a/dredis/contrib/convert_key_format_to_2_5_3.py
+++ b/dredis/contrib/convert_key_format_to_2_5_3.py
@@ -1,0 +1,104 @@
+"""
+In case the migration to the new key format using key IDs didn't go as expected,
+you can convert them back using this script.
+
+Example with dredis after 2.5.3 (the format isn't accurate, it's simplified to explain the idea):
+    hset h name hugo
+
+    4_h = keyID,1
+    5_keyID_name = 'hugo'
+
+The script converts those keys to the 2.5.3 format:
+    4_h = 1
+    5_h_name = 'hugo'
+
+
+Real example (start with dredis later than 2.5.3)
+-------------------------------------------------
+
+1. Keys at the start
+    "\x04\x00\x00\x00\x01h" = "h\xb8=\xb7\x8c\xfeK9\x8b\xdc`\x03\x81D9\b1"
+    "\x05\x00\x00\x00\x10h\xb8=\xb7\x8c\xfeK9\x8b\xdc`\x03\x81D9\bname" = "hugo"
+
+2. Convert the keys using this script
+    $ PYTHONPATH=. python dredis/contrib/convert_key_format_to_2_5_3.py  --dir /tmp/dredis-data --backend leveldb
+    Converting '\x04\x00\x00\x00\x01h'
+    batch.put('\x04\x00\x00\x00\x10h\xb8=\xb7\x8c\xfeK9\x8b\xdc`\x03\x81D9\x08', '1')
+    batch.delete('\x04\x00\x00\x00\x01h')
+    [TO RUN] RENAME "h\xb8=\xb7\x8c\xfeK9\x8b\xdc`\x03\x81D9\x08" "h"
+
+At the end of step 2, the keys will be properly set up but have weird names:
+    "\x04\x00\x00\x00\x10h\xb8=\xb7\x8c\xfeK9\x8b\xdc`\x03\x81D9\b" = "1"
+    "\x05\x00\x00\x00\x10h\xb8=\xb7\x8c\xfeK9\x8b\xdc`\x03\x81D9\bname" = "hugo"
+
+3. Run dredis 2.5.3 or ealier
+
+4. Run the RENAMEs from step 2
+    $ redis-cli
+    127.0.0.1:6379> RENAME "h\xb8=\xb7\x8c\xfeK9\x8b\xdc`\x03\x81D9\x08" "h"
+    OK
+
+5. Keys at the end
+    "\x04\x00\x00\x00\x01h" = "1"
+    "\x05\x00\x00\x00\x01hname" = "hugo"
+"""
+import argparse
+
+from dredis.db import NUMBER_OF_REDIS_DATABASES, DB_MANAGER, KEY_CODEC, UUID_LENGTH_IN_BYTES
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dir', help='dredis data directory', required=True)
+    parser.add_argument('--backend', choices=['lmdb', 'leveldb'], help='output file type', required=True)
+    args = parser.parse_args()
+
+    DB_MANAGER.setup_dbs(args.dir, args.backend, {})
+    revert_collections_to_dredis_2_5_3_format()
+
+
+def revert_collections_to_dredis_2_5_3_format():
+    for db_id in range(NUMBER_OF_REDIS_DATABASES):
+        db = DB_MANAGER.get_db(db_id)
+        for key_prefix in [
+            KEY_CODEC.SET_TYPE,
+            KEY_CODEC.HASH_TYPE,
+            KEY_CODEC.ZSET_TYPE,
+        ]:
+            with db.write_batch() as batch:
+                _convert(db, batch, chr(key_prefix))
+
+
+def _convert(db, batch, key_prefix):
+    for db_key, db_value in db.iterator(prefix=key_prefix):
+        print('Converting %r' % db_key)
+        _convert_key(batch, db_key, db_value)
+
+
+def _convert_key(batch, db_key, db_value):
+    type_id, _, key = KEY_CODEC.decode_key(db_key)
+    if len(db_value) < UUID_LENGTH_IN_BYTES:
+        # older schema before uuid
+        key_id = key
+        length = db_value
+    else:
+        # new schema with uuid
+        key_id = db_value[:UUID_LENGTH_IN_BYTES]
+        length = db_value[UUID_LENGTH_IN_BYTES:]
+    print('batch.put({!r}, {!r})'.format(KEY_CODEC.get_key(key_id, type_id), length))
+    batch.put(KEY_CODEC.get_key(key_id, type_id), length)
+    if key != key_id:
+        batch.delete(db_key)
+        print('batch.delete({!r})'.format(db_key))
+        print('[TO RUN] RENAME {} {}'.format(_rediscli_str(key_id), _rediscli_str(key)))
+
+
+def _rediscli_str(s):
+    """
+    convert to a string that the redis-cli understands and escape properly
+    """
+    return '"{}"'.format(repr(s)[1:-1].replace('"', r'\"'))
+
+
+if __name__ == '__main__':
+    main()

--- a/dredis/db.py
+++ b/dredis/db.py
@@ -94,6 +94,9 @@ class KeyCodec(object):
     def encode_deleted_hash(self, key_id):
         return self.get_key(self.get_min_hash_field(key_id), self.DELETED_KEY_TYPE)
 
+    def encode_deleted_set(self, key_id):
+        return self.get_key(self.get_min_set_member(key_id), self.DELETED_KEY_TYPE)
+
     def decode_key(self, key):
         type_id, key_length = self.KEY_PREFIX_STRUCT.unpack(key[:self.KEY_PREFIX_LENGTH])
         key_value = key[self.KEY_PREFIX_LENGTH:]

--- a/dredis/db.py
+++ b/dredis/db.py
@@ -91,6 +91,9 @@ class KeyCodec(object):
     def encode_deleted_zset_value(self, key_id):
         return self.get_key(self.get_min_zset_value(key_id), self.DELETED_KEY_TYPE)
 
+    def encode_deleted_hash(self, key_id):
+        return self.get_key(self.get_min_hash_field(key_id), self.DELETED_KEY_TYPE)
+
     def decode_key(self, key):
         type_id, key_length = self.KEY_PREFIX_STRUCT.unpack(key[:self.KEY_PREFIX_LENGTH])
         key_value = key[self.KEY_PREFIX_LENGTH:]

--- a/dredis/db.py
+++ b/dredis/db.py
@@ -117,12 +117,16 @@ class KeyCodec(object):
             Previously the following keys would be created
                 6_z = 2
                 7_z_alice = 100
-                7_z_100_alice = ''
+                7_z_bob = 200
+                8_z_100_alice = ''
+                8_z_100_alice = ''
 
             New approach:
                 6_z = uniqueID_2
                 7_uniqueID_alice = 100
-                7_uniqueID_100_alice = ''
+                7_uniqueID_bob = 200
+                8_uniqueID_100_alice = ''
+                8_uniqueID_100_bob = ''
 
             Then on deletions, the "pointer" key should be removed immediately and the related keys marked
             to be removed asynchronously. The next time a `zadd z` is executed, it will get a new unique ID

--- a/dredis/db.py
+++ b/dredis/db.py
@@ -115,7 +115,7 @@ class KeyCodec(object):
             key_id = uuid.uuid4().bytes
             length = '0'
         else:
-            if db_value < uuid_length_in_bytes:
+            if len(db_value) < uuid_length_in_bytes:
                 # older schema before uuid
                 key_id = key
                 length = db_value

--- a/dredis/gc.py
+++ b/dredis/gc.py
@@ -4,8 +4,8 @@ import time
 from dredis.db import NUMBER_OF_REDIS_DATABASES, DB_MANAGER, KEY_CODEC
 
 
-DEFAULT_GC_INTERVAL = 10  # milliseconds
-DEFAULT_GC_BATCH_SIZE = 1000  # number of storage keys to delete in a batch
+DEFAULT_GC_INTERVAL = 500  # milliseconds
+DEFAULT_GC_BATCH_SIZE = 10000  # number of storage keys to delete in a batch
 
 
 class KeyGarbageCollector(threading.Thread):

--- a/dredis/gc.py
+++ b/dredis/gc.py
@@ -1,0 +1,38 @@
+import threading
+import time
+
+from dredis.db import NUMBER_OF_REDIS_DATABASES, DB_MANAGER, KEY_CODEC
+
+
+DEFAULT_GC_INTERVAL = 10  # milliseconds
+DEFAULT_GC_BATCH_SIZE = 1000  # number of storage keys to delete in a batch
+
+
+class KeyGarbageCollector(threading.Thread):
+
+    def __init__(self, gc_interval=DEFAULT_GC_INTERVAL, batch_size=DEFAULT_GC_BATCH_SIZE):
+        threading.Thread.__init__(self, name="Key Garbage Collector")
+        self._gc_interval_in_secs = gc_interval / 1000.0  # convert to seconds
+        self._batch_size = batch_size
+
+    def run(self):
+        while True:
+            self.collect()
+            time.sleep(self._gc_interval_in_secs)
+
+    def collect(self):
+        for db_id in range(NUMBER_OF_REDIS_DATABASES):
+            with DB_MANAGER.thread_lock:
+                self._collect(DB_MANAGER.get_db(db_id))
+
+    def _collect(self, db):
+        deleted = 0
+        with db.write_batch() as batch:
+            for deleted_db_key, _ in db.iterator(prefix=KEY_CODEC.MIN_DELETED_VALUE):
+                _, _, deleted_key_value = KEY_CODEC.decode_key(deleted_db_key)
+                for db_key, _ in db.iterator(prefix=deleted_key_value):
+                    deleted += 1
+                    batch.delete(db_key)
+                    if deleted == self._batch_size:
+                        return
+                batch.delete(deleted_db_key)

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -207,7 +207,7 @@ class Keyspace(object):
                 return 0
             result = 1
             zset_length += 1
-            batch.put(KEY_CODEC.encode_zset(key), KEY_CODEC.encode_key_id_and_length(key_id, zset_length))
+            batch.put(KEY_CODEC.encode_zset(key), KEY_CODEC.encode_key_id_and_length(key, key_id, zset_length))
 
         batch.put(KEY_CODEC.encode_zset_value(key_id, value), to_float_string(score))
         batch.put(KEY_CODEC.encode_zset_score(key_id, value, score), bytes(''))
@@ -292,7 +292,7 @@ class Keyspace(object):
         if zset_length == 0:
             self.delete(key)
         else:
-            batch.put(KEY_CODEC.encode_zset(key), KEY_CODEC.encode_key_id_and_length(key_id, zset_length))
+            batch.put(KEY_CODEC.encode_zset(key), KEY_CODEC.encode_key_id_and_length(key, key_id, zset_length))
             batch.write()
         return result
 

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -166,11 +166,13 @@ class Keyspace(object):
         # there are two sets of db keys for hashes:
         # * hash
         # * hash fields
+        #
+        # current the `hash` key is immediately deleted and the other keys
+        # will be collected by gc.KeyGarbageCollector()
         key_id, _ = self._get_hash_key_id_and_length(key)
         with self._db.write_batch() as batch:
             batch.delete(KEY_CODEC.encode_hash(key))
-            for db_key, _ in self._get_db_iterator(KEY_CODEC.get_min_hash_field(key_id)):
-                batch.delete(db_key)
+            batch.put(KEY_CODEC.encode_deleted_hash(key_id), bytes(''))
 
     def _delete_db_zset(self, key):
         # there are three sets of db keys for zsets:

--- a/dredis/keyspace.py
+++ b/dredis/keyspace.py
@@ -430,7 +430,7 @@ class Keyspace(object):
         if self._db.get(KEY_CODEC.encode_hash_field(key_id, field)) is None:
             result = 1
         with self._db.write_batch() as batch:
-            batch.put(KEY_CODEC.encode_hash(key), KEY_CODEC.encode_key_id_and_length(key, key_id, hash_length + 1))
+            batch.put(KEY_CODEC.encode_hash(key), KEY_CODEC.encode_key_id_and_length(key, key_id, hash_length + result))
             batch.put(KEY_CODEC.encode_hash_field(key_id, field), value)
         return result
 

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -12,7 +12,7 @@ import traceback
 import sys
 
 from dredis import __version__
-from dredis import db, rdb, config
+from dredis import db, rdb, config, gc
 from dredis.commands import run_command, SimpleString
 from dredis.exceptions import DredisError
 from dredis.keyspace import Keyspace, to_float_string
@@ -156,6 +156,10 @@ def main():
     parser.add_argument('--readonly', action='store_true', help='accept read-only commands')
     parser.add_argument('--requirepass', default='',
                         help='require clients to issue AUTH <password> before processing any other commands')
+    parser.add_argument('--gc-interval', default=gc.DEFAULT_GC_INTERVAL,
+                        type=float, help='key gc interval in milliseconds (defaults to %(default)s)')
+    parser.add_argument('--gc-batch-size', default=gc.DEFAULT_GC_BATCH_SIZE,
+                        type=float, help='key gc batch size (defaults to %(default)s)')
     args = parser.parse_args()
 
     global ROOT_DIR
@@ -194,6 +198,9 @@ def main():
         logger.info("Finished loading (%.2f seconds)." % (time.time() - start_time))
 
     RedisServer(args.host, args.port)
+    gc_thread = gc.KeyGarbageCollector(args.gc_interval, args.gc_batch_size)
+    gc_thread.setDaemon(True)
+    gc_thread.start()
 
     logger.info("Backend: {}".format(args.backend))
     logger.info("Port: {}".format(args.port))

--- a/dredis/server.py
+++ b/dredis/server.py
@@ -199,7 +199,7 @@ def main():
 
     RedisServer(args.host, args.port)
     gc_thread = gc.KeyGarbageCollector(args.gc_interval, args.gc_batch_size)
-    gc_thread.setDaemon(True)
+    gc_thread.daemon = True
     gc_thread.start()
 
     logger.info("Backend: {}".format(args.backend))

--- a/tests-performance/test_lua_performance.py
+++ b/tests-performance/test_lua_performance.py
@@ -19,6 +19,6 @@ def test_lua_evaluation():
     r = fresh_redis(port=PROFILE_PORT)
     before_eval = time.time()
     for score in range(LARGE_NUMBER):
-        assert r.eval("return 1".format(score), 0) == 1
+        assert r.eval("return 1", 0) == 1
     after_eval = time.time()
     print '\nLua EVAL time = {:.5f}s'.format(after_eval - before_eval)

--- a/tests/integration/test_hash.py
+++ b/tests/integration/test_hash.py
@@ -19,6 +19,8 @@ def test_hset_and_hget():
     assert r.hget('myhash', 'key2') == 'value2'
     assert r.hget('myhash', 'notfound') is None
 
+    assert r.hlen('myhash') == 2
+
 
 def test_hkeys():
     r = fresh_redis()

--- a/tests/integration/test_leveldb.py
+++ b/tests/integration/test_leveldb.py
@@ -1,5 +1,6 @@
 import tempfile
 
+from dredis.gc import KeyGarbageCollector
 from dredis.keyspace import Keyspace
 from dredis.db import DB_MANAGER
 
@@ -16,5 +17,7 @@ def test_delete():
     keyspace.hset('myhash', 'testkey', 'testvalue')
 
     keyspace.delete('mystr', 'myset', 'myzset', 'myhash', 'notfound')
+
+    KeyGarbageCollector().collect()
 
     assert list(DB_MANAGER.get_db('0').iterator()) == []

--- a/tests/integration/test_zset.py
+++ b/tests/integration/test_zset.py
@@ -30,21 +30,27 @@ def test_zadd_with_multiple_parameters():
 
 def test_zset_zrange_with_positive_indexes():
     r = fresh_redis()
-    r.zadd('myzset', 0, 'myvalue1')
-    r.zadd('myzset', 1, 'myvalue2')
-    assert r.zrange('myzset', 0, 1) == ['myvalue1', 'myvalue2']
-    assert r.zrange('myzset', 0, 100) == ['myvalue1', 'myvalue2']
+    r.zadd('z1', 0, 'z1-v1')
+    r.zadd('z1', 1, 'z1-v2')
+    r.zadd('z2', 0, 'z2-v1')
+    r.zadd('z2', 1, 'z2-v2')
+    assert r.zrange('z1', 0, 1) == ['z1-v1', 'z1-v2']
+    assert r.zrange('z1', 0, 100) == ['z1-v1', 'z1-v2']
+    assert r.zrange('z2', 0, 1) == ['z2-v1', 'z2-v2']
+    assert r.zrange('z2', 0, 100) == ['z2-v1', 'z2-v2']
 
 
 def test_zset_zrange_with_negative_indexes():
     r = fresh_redis()
-    r.zadd('myzset', 0, 'myvalue1')
-    r.zadd('myzset', 1, 'myvalue2')
-    assert r.zrange('myzset', 0, -1) == ['myvalue1', 'myvalue2']
-    assert r.zrange('myzset', 0, -2) == ['myvalue1']
-    assert r.zrange('myzset', 0, -3) == []
+    r.zadd('z1', 0, 'z1-v1')
+    r.zadd('z1', 1, 'z1-v2')
+    r.zadd('z2', 0, 'z2-v1')
+    r.zadd('z2', 1, 'z2-v2')
+    assert r.zrange('z1', 0, -1) == ['z1-v1', 'z1-v2']
+    assert r.zrange('z1', 0, -2) == ['z1-v1']
+    assert r.zrange('z1', 0, -3) == []
 
-    assert r.zrange('myzset', -2, 1) == ['myvalue1', 'myvalue2']
+    assert r.zrange('z1', -2, 1) == ['z1-v1', 'z1-v2']
 
 
 def test_redis_official_zset_tests_for_zrange():


### PR DESCRIPTION
This is a new and experimental feature that was necessary at Yipit to offload dredis on `RENAME` and `DEL` operations.
When a sorted set, hash, or set is stored using any of the backends, dredis creates a few keys in the backend for each element of those collections.
With this new feature, on `RENAME` and `DELETE`, only the key holding the key ID/pointer is replaced/deleted.
There's a background thread that periodically deletes those related keys from the storage backend (you can tweak the GC options via `--gc-interval` and `--gc-batch-size`).
Despite the asynchronous deletions, the deletion operation still ensures strong consistency because of the use of key IDs/pointers.

If you don't want this experimental feature, you need to go back to DRedis 2.5.3.

-----

The previous approach after `ZADD z 100 alice 200 bob` in dredis would create these keys in the backend (LMDB/LevelDB/memory):
```
    6_z = 2
    7_z_alice = 100
    7_z_bob = 200
    8_z_100_alice = ''
    8_z_200_bob = ''
```

`RENAME z new-z` would do the following in the backend:
```
[del]    6_z = 2
[del]    7_z_alice = 100
[del]    7_z_bob = 200
[del]    8_z_100_alice = ''
[del]    8_z_200_bob = ''

[put]    6_new-z = 2
[put]    7_new-z_alice = 100
[put]    7_new-z_bob = 200
[put]    8_new-z_100_alice = ''
[put]    8_new-z_200_bob = ''
```

And `DEL z` would do:
```
[del]    6_z = 2
[del]    7_z_alice = 100
[del]    7_z_bob = 200
[del]    8_z_100_alice = ''
[del]    8_z_200_bob = ''
```

As you can tell, the previous approach is a linear operation; O(N) where N is the total number of keys related to that zset.

**The new approach is designed to be constant; O(1) instead of O(N).**

With the new approach, `ZADD z 100 alice 200 bob` creates the following:
```
    6_z = uniqueID_2
    7_uniqueID_alice = 100
    7_uniqueID_bob = 200
    8_uniqueID_100_alice = ''
    8_uniqueID_100_bob = ''
```

After `RENAME z new-z`:
```
[del] 6_z = uniqueID_2
[put] 6_new-z = uniqueID_2
```

And `DEL z` would do:
```
[del] 6_z = uniqueID_2
[put] x_7_uniqueID = ''
[put] x_8_uniqueID = ''
```

The `x_` prefix indicates the prefixes after that should be removed from the backend by the GC. The GC will periodically delete a batch of keys instead of all at once to avoid Python from hanging at that operation for too long.

In practice, those prefixes are bytes and the unique IDs are UUID4.

-----

I have mixed feelings about the thead code, but LevelDB doesn't allow separate processes to work with the same database. The thread solution is easier to operate because it's a single process. Redis also has a background thread to expire keys, despite being seen as single-threaded.

-----

This pull request works with existing data, but whenever it changes a zset/set/hash, it will change the existing data structure and make it impossible to downgrade to dredis 2.5.3 or earlier.

cc @jimjshields, @spulec 