### PR TITLE
Add contrib/snapshot_leveldb.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ python:
   - "2.7"
 services:
   - redis-server
+before_install:
+  - sudo apt-get update -q
+  - sudo apt-get install -y libleveldb-dev
 install: make setup
 env:
   - TEST_SUITE=fulltests BACKEND="--backend memory"

--- a/dredis/contrib/snapshot_leveldb.py
+++ b/dredis/contrib/snapshot_leveldb.py
@@ -1,0 +1,65 @@
+import argparse
+import datetime
+import json
+import logging
+import shutil
+import sys
+
+from dredis import db
+from dredis.keyspace import Keyspace
+
+logger = logging.getLogger(__name__)
+BACKEND = 'leveldb'
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dir', help='dredis data directory', required=True)
+    parser.add_argument('--output', choices=['leveldb', 'rdb'], help='output file type', required=True)
+    parser.add_argument('--backend-option', action='append',
+                        help='database backend options (e.g., --backend-option map_size=BYTES)')
+    args = parser.parse_args()
+
+    db_backend_options = {}
+    if args.backend_option:
+        for option in args.backend_option:
+            if '=' not in option:
+                logger.error('Expected `key=value` pairs for --backend-option parameter')
+                sys.exit(1)
+            key, value = map(str.strip, option.split('='))
+            db_backend_options[key] = json.loads(value)
+
+    logger.info("Copying LevelDB files...")
+    output_dir = copy_dirs(args.dir, db_backend_options)
+
+    if args.output == 'rdb':
+        logger.info("Saving RDB file...")
+        save_rdb(output_dir, db_backend_options)
+        shutil.rmtree(output_dir)
+
+    logger.info("Done!")
+
+
+def save_rdb(output_dir, db_backend_options):
+    db.DB_MANAGER.setup_dbs(output_dir, BACKEND, db_backend_options)
+    keyspace = Keyspace()
+    keyspace.save()
+
+
+def copy_dirs(input_basedir, db_backend_options):
+    output_basedir = datetime.datetime.utcnow().strftime('leveldb-backup_%Y-%m-%dT%H:%M:%S')
+    shutil.copytree(input_basedir, output_basedir)
+    return output_basedir
+
+
+def setup_logging(level):
+    logger.setLevel(level)
+    formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(message)s')
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+
+if __name__ == '__main__':
+    setup_logging(logging.INFO)
+    main()


### PR DESCRIPTION
A copy of snapshot_lmdb with adapations to leveldb. The main difference is
that it uses shutil.copytree() to copy the whole LevelDB directory.

This script is only safe when the dredis server is stopped to guarantee
that all LevelDB in-memory operations made it to the filesystem!


-----

I tested it locally with this:
```
$ python -m dredis.server --port 6377 --backend leveldb --dir /tmp/dredis-data-test &
[1] 92257

$ 2020-10-22 12:49:31,388 [INFO] Backend: leveldb
2020-10-22 12:49:31,388 [INFO] Port: 6377
2020-10-22 12:49:31,388 [INFO] Root directory: /tmp/dredis-data-test
2020-10-22 12:49:31,388 [INFO] PID: 92257
2020-10-22 12:49:31,388 [INFO] Readonly: false
2020-10-22 12:49:31,388 [INFO] Ready to accept connections


$ redis-cli -p 6377 set test "hello hugo"
OK

$ fg
python -m dredis.server --port 6377 --backend leveldb --dir /tmp/dredis-data-test
^C2020-10-22 12:49:45,847 [INFO] Shutting down...


$ python -m dredis.contrib.snapshot_leveldb --dir /tmp/dredis-data-test --output rdb
2020-10-22 12:50:40,416 [INFO] Copying LevelDB files...
2020-10-22 12:50:40,487 [INFO] Saving RDB file...
2020-10-22 12:50:41,835 [INFO] Done!

$ cp dump*rdb /tmp/dump.rdb

$ cd /tmp

$ redis-server &
[1] 93378
93378:C 22 Oct 2020 12:51:02.242 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
93378:C 22 Oct 2020 12:51:02.242 # Redis version=5.0.3, bits=64, commit=00000000, modified=0, pid=93378, just started
93378:C 22 Oct 2020 12:51:02.242 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
                _._                                                  
           _.-``__ ''-._                                             
      _.-``    `.  `_.  ''-._           Redis 5.0.3 (00000000/0) 64 bit
  .-`` .-```.  ```\/    _.,_ ''-._                                   
 (    '      ,       .-`  | `,    )     Running in standalone mode
 |`-._`-...-` __...-.``-._|'` _.-'|     Port: 6379
 |    `-._   `._    /     _.-'    |     PID: 93378
  `-._    `-._  `-./  _.-'    _.-'                                   
 |`-._`-._    `-.__.-'    _.-'_.-'|                                  
 |    `-._`-._        _.-'_.-'    |           http://redis.io        
  `-._    `-._`-.__.-'_.-'    _.-'                                   
 |`-._`-._    `-.__.-'    _.-'_.-'|                                  
 |    `-._`-._        _.-'_.-'    |                                  
  `-._    `-._`-.__.-'_.-'    _.-'                                   
      `-._    `-.__.-'    _.-'                                       
          `-._        _.-'                                           
              `-.__.-'                                               

93378:M 22 Oct 2020 12:51:02.246 # Server initialized
93378:M 22 Oct 2020 12:51:02.246 * DB loaded from disk: 0.000 seconds
93378:M 22 Oct 2020 12:51:02.246 * Ready to accept connections

$ redis-cli -p 6379 get test
"hello hugo"

$ 

```